### PR TITLE
New build-version output method

### DIFF
--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -130,6 +130,20 @@ module Omnibus
       build_tag
     end
 
+    # Generates a version string compliant with Datadog agent stable/nightly builds
+    # It works as a patch on top of Omnibus::BuildVersion#semver.
+    # Returns:
+    #  - For stable builds: `semver` output
+    #  - For nightly builds: AGENT_VERSION+git.COMMITS_SINCE.GIT_SHA
+    #    (where `AGENT_VERSION` is an environment variable)
+    def dd_agent_format
+      agent_version = semver
+      if ENV['AGENT_VERSION'] and ENV['AGENT_VERSION'].length > 1 and agent_version.include? "git"
+        agent_version = ENV['AGENT_VERSION'] + "+" + agent_version.split("+")[1]
+      end
+      agent_version
+    end
+
     # Generates a version string by running
     # {https://www.kernel.org/pub/software/scm/git/docs/git-describe.html
     # git describe} in the root of the Omnibus project.


### PR DESCRIPTION
Compliant with dd-agent stable/nightly builds