### PR TITLE
[rpm] Remove epoch from final RPM name

### DIFF
--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -136,7 +136,9 @@ module Omnibus
       if ENV['AGENT_VERSION'] and ENV['AGENT_VERSION'].length > 1 and agent_version.include? "git"
         agent_version = ENV['AGENT_VERSION'] + "+" + agent_version.split("+")[1]
       end
-      agent_version = "1:" + agent_version
+      if ohai['platform_family'] == 'debian'
+        agent_version = "1:" + agent_version
+      end
       agent_version
     end
 

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -136,9 +136,6 @@ module Omnibus
       if ENV['AGENT_VERSION'] and ENV['AGENT_VERSION'].length > 1 and agent_version.include? "git"
         agent_version = ENV['AGENT_VERSION'] + "+" + agent_version.split("+")[1]
       end
-      if ohai['platform_family'] == 'debian'
-        agent_version = "1:" + agent_version
-      end
       agent_version
     end
 

--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -181,7 +181,7 @@ module Omnibus
     # extension.
     #
     def package_name
-      return "#{safe_base_package_name}_#{safe_version}-#{safe_build_iteration}_#{safe_architecture}.deb".sub(/\d+:/, '')
+      return "#{safe_base_package_name}_#{safe_version}-#{safe_build_iteration}_#{safe_architecture}.deb"
     end
 
     #
@@ -207,7 +207,7 @@ module Omnibus
         destination: File.join(debian_dir, 'control'),
         variables: {
           name:           safe_base_package_name,
-          version:        safe_version,
+          version:        "1:" + safe_version,
           iteration:      safe_build_iteration,
           vendor:         vendor,
           license:        license,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -216,7 +216,7 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      return "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
+      return "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm".sub(/\d+:/, '')
     end
 
     #
@@ -336,7 +336,7 @@ module Omnibus
       end
 
       FileSyncer.glob("#{staging_dir}/RPMS/**/*.rpm").each do |rpm|
-        copy_file(rpm, Config.package_dir)
+        copy_file(rpm, "#{Config.package_dir}/#{rpm.split('/')[-1].sub(/\d+:/, '')}" )
       end
     end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -216,7 +216,7 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      return "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm".sub(/\d+:/, '')
+      return "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
     end
 
     #
@@ -336,7 +336,7 @@ module Omnibus
       end
 
       FileSyncer.glob("#{staging_dir}/RPMS/**/*.rpm").each do |rpm|
-        copy_file(rpm, "#{Config.package_dir}/#{rpm.split('/')[-1].sub(/\d+:/, '')}" )
+        copy_file(rpm, "#{Config.package_dir}/#{rpm.split('/')[-1]}" )
       end
     end
 


### PR DESCRIPTION
The colon is not really HTTP compliant and also, this has been done to have consistent rpm names regarding the previous versions.