### PR TITLE
Add a real epoch DSL for RPM and DEB builds

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -123,6 +123,29 @@ module Omnibus
     expose :license
 
     #
+    # Sets or return the epoch for this package
+    #
+    # @example
+    #   epoch 1
+    # @param [Integer] val
+    #   the epoch number
+    #
+    # @return [Integer]
+    #   the epoch of the current package
+    def epoch(val = NULL)
+      if null?(val)
+        @epoch || NULL
+      else
+        unless val.is_a?(Integer)
+          raise InvalidValue.new(:epoch, 'be an Integer')
+        end
+
+        @epoch = val
+      end
+    end
+    expose :epoch
+
+    #
     # Set or return the priority for this package.
     #
     # @example
@@ -207,7 +230,7 @@ module Omnibus
         destination: File.join(debian_dir, 'control'),
         variables: {
           name:           safe_base_package_name,
-          version:        "1:" + safe_version,
+          version:        (if null?(epoch) then '' else "#{epoch}:" end) + safe_version,
           iteration:      safe_build_iteration,
           vendor:         vendor,
           license:        license,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -134,6 +134,29 @@ module Omnibus
     expose :vendor
 
     #
+    # Sets or return the epoch for this package
+    #
+    # @example
+    #   epoch 1
+    # @param [Integer] val
+    #   the epoch number
+    #
+    # @return [Integer]
+    #   the epoch of the current package
+    def epoch(val = NULL)
+      if null?(val)
+        @epoch || NULL
+      else
+        unless val.is_a?(Integer)
+          raise InvalidValue.new(:epoch, 'be an Integer')
+        end
+
+        @epoch = val
+      end
+    end
+    expose :epoch
+
+    #
     # Set or return the license for this package.
     #
     # @example
@@ -167,6 +190,7 @@ module Omnibus
     # @param [String] val
     #   the priority for this package
     #
+
     # @return [String]
     #   the priority for this package
     #
@@ -267,6 +291,7 @@ module Omnibus
         variables: {
           name:           safe_base_package_name,
           version:        safe_version,
+          epoch:          epoch,
           iteration:      safe_build_iteration,
           vendor:         vendor,
           license:        license,
@@ -336,7 +361,9 @@ module Omnibus
       end
 
       FileSyncer.glob("#{staging_dir}/RPMS/**/*.rpm").each do |rpm|
-        copy_file(rpm, "#{Config.package_dir}/#{rpm.split('/')[-1]}" )
+        # RPMbuild doesn't let use choose the final RPM name, it contains the epoch if the
+        # corresponding DSL was set so... let's get rid from the RPM name here :/
+        copy_file(rpm, "#{Config.package_dir}/#{rpm.split('/')[-1].sub(/\d+:/, '')}" )
       end
     end
 

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -17,6 +17,7 @@
 # Metadata
 Name: <%= name %>
 Version: <%= version %>
+Epoch: <%= epoch %>
 Release: <%= iteration %>
 Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
 BuildArch: <%= architecture %>


### PR DESCRIPTION
This replaces the dirty hack that was there before and actually makes
things work for real with RPM packages as explained below.

The epoch shouldn't be included as part of the version string for RPMs
but as a separate field in the package metadata (contrary to what's
happening for debs). I updated our fork by actually (re)adding an epoch
DSL for RPM and DEB builds which is definitely cleaner than what we were
doing before. Will make a PR for that against `chef/omnibus` when I get
the chance, it might definitely be a relevant DSL to other Omnibus users.