### PR TITLE
Fixed the RPM build when the epoch DSL is unset

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -145,13 +145,13 @@ module Omnibus
     #   the epoch of the current package
     def epoch(val = NULL)
       if null?(val)
-        @epoch || NULL
+        @epoch || ''
       else
         unless val.is_a?(Integer)
           raise InvalidValue.new(:epoch, 'be an Integer')
         end
 
-        @epoch = val
+        @epoch = val.to_s
       end
     end
     expose :epoch

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -17,7 +17,9 @@
 # Metadata
 Name: <%= name %>
 Version: <%= version %>
+<% if not epoch.empty? -%>
 Epoch: <%= epoch %>
+<% end -%>
 Release: <%= iteration %>
 Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
 BuildArch: <%= architecture %>


### PR DESCRIPTION
The build was broken because only `:` was inserted into the RPM package
name when no epoch was set which wasn't caught by the `\d+:` RegEx. No
when no epoch is set, no epoch is passed to the `rpmbuild` command and
the RPM doesn't have any extra colon. When it is defined, the epoch is
removed by the regex as it was before :)