### PR TITLE
[Windows] Allow extra package files to be shipped

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -94,12 +94,12 @@ module Omnibus
     #   the pip subcommand to execute
     #
     # @return [void]
-    def pip_call(subcommand)
+    def pip_call(subcommand, options = {})
      pip_path = "\"#{install_dir}/embedded/bin/pip\""
      if Ohai['platform'] == "windows"
        pip_path = "\"#{windows_safe_path(install_dir)}\\embedded\\Scripts\\pip.exe\""
      end
-     command("#{pip_path} #{subcommand}")
+     command("#{pip_path} #{subcommand}", options)
     end
     expose :pip_call
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -88,6 +88,22 @@ module Omnibus
     expose :command
 
     #
+    # Calls the embedded pip (Datadog specific function)
+    #
+    # @param [String] subcommand
+    #   the pip subcommand to execute
+    #
+    # @return [void]
+    def pip_call(subcommand)
+     pip_path = "\"#{install_dir}/embedded/bin/pip\""
+     if Ohai['platform'] == "windows"
+       pip_path = "\"#{windows_safe_path(install_dir)}\\embedded\\Scripts\\pip.exe\""
+     end
+     command("#{pip_path} #{subcommand}")
+    end
+    expose :pip_call
+
+    #
     # Execute the given make command. When present, this method will prefer the
     # use of +gmake+ over +make+. If applicable, this method will also set
     # the `MAKE=gmake` environment variable when gmake is to be preferred.

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -64,7 +64,7 @@ module Omnibus
         false
       else
         create_directory(File.dirname(cache_path))
-        shellout!("git --git-dir=#{cache_path} init -q")
+        shellout!("git --git-dir=\"#{cache_path}\" init -q")
         true
       end
     end
@@ -113,15 +113,15 @@ module Omnibus
       create_cache_path
       remove_git_dirs
 
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} add -A -f))
+      shellout!(%Q(git --git-dir=\"#{cache_path}\" --work-tree=\"#{install_dir}\" add -A -f))
 
       begin
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{tag}"))
+        shellout!(%Q(git --git-dir=\"#{cache_path}\" --work-tree=\"#{install_dir}\" commit -q -m "Backup of #{tag}"))
       rescue CommandFailed => e
         raise unless e.message.include?('nothing to commit')
       end
 
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f "#{tag}"))
+      shellout!(%Q(git --git-dir=\"#{cache_path}\" --work-tree=\"#{install_dir}\" tag -f "#{tag}"))
     end
 
     def restore
@@ -129,7 +129,7 @@ module Omnibus
 
       create_cache_path
 
-      cmd = shellout(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{tag}"))
+      cmd = shellout(%Q(git --git-dir=\"#{cache_path}\" --work-tree=\"#{install_dir}\" tag -l "#{tag}"))
 
       restore_me = false
       cmd.stdout.each_line do |line|
@@ -138,7 +138,7 @@ module Omnibus
 
       if restore_me
         log.internal(log_key) { "Detected tag `#{tag}' can be restored, restoring" }
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{tag}"))
+        shellout!(%Q(git --git-dir=\"#{cache_path}\" --work-tree=\"#{install_dir}\" checkout -f "#{tag}"))
         true
       else
         log.internal(log_key) { "Could not find tag `#{tag}', skipping restore" }

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -181,6 +181,7 @@ module Omnibus
           when '5.1.2600', 'xp'     then 'xp'
           when '5.2.3790', '2003r2' then '2003r2'
           when '6.0.6001', '2008'   then '2008'
+          when '6.0.6002', '2008'   then '2008'
           when '6.1.7600', '7'      then '7'
           when '6.1.7601', '2008r2' then '2008r2'
           when '6.2.9200', '8'      then '8'

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -550,10 +550,10 @@ module Omnibus
 
     #
     # Downloads a software license to ship with the final build.
-    # 
+    #
     # Licenses will be copied into {install_dir}/sources/{software_name}
     #
-    # @param [String] name_or_url 
+    # @param [String] name_or_url
     #   the name of the license to ship or a URL pointing to the license file.
     #
     #   Available License Names : LGPLv2, LGPLv3, PSFL, Apache, Apachev2,
@@ -562,8 +562,8 @@ module Omnibus
     # @example
     #   ship_license 'GPLv3'
     #
-    # @example 
-    #    ship_license 'http://www.r-project.org/Licenses/GPL-3' 
+    # @example
+    #    ship_license 'http://www.r-project.org/Licenses/GPL-3'
     #
     def ship_license(name_or_url)
       @ship_license
@@ -577,7 +577,7 @@ module Omnibus
     #
     # @param [String] url
     #   An URL pointing to a source code archive
-    #   
+    #
     def ship_source(url)
         @ship_source
     end


### PR DESCRIPTION
We don't have an `extra_package_file` directive for Windows builds
(there's one but it doesn't do anything) and as a matter of fact, it
wouldn't make much sense since the directories in whcih we'd like to put
these files are often User/System dependant or user configurable.

We added a routine to add such files under a directory defined in the
`source.wxs` file and referenced by it's id. To achieve that, the only
thing that needs to be done is to copy the extra files under
`<main_software_source_dir>/EXTRA_PACKAGE_FILES/DIRECTORY_ID`.

I'll try to figure out a cleaner way and have it packaged in the next
Omnibus release but for now this does the trick pretty well :)