### PR TITLE
[SDK] Support package extension

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -439,5 +439,24 @@ module Omnibus
         Ohai['kernel']['machine']
       end
     end
+
+    #
+    # Install the specified package
+    #
+    # @return [void]
+    #
+    def install(package, _)
+      `apt-get update && apt-get install -y --force-yes #{package}`
+    end
+
+    #
+    # Remove the specified package
+    #
+    # @return [void]
+    #
+    def remove(package)
+      `apt-get remove -y --force-yes #{package}`
+    end
+
   end
 end

--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -445,7 +445,7 @@ module Omnibus
     #
     # @return [void]
     #
-    def install(packages, _)
+    def install(packages, _ = NULL)
       `apt-get update && apt-get install -y --force-yes #{packages}`
     end
 

--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -441,21 +441,21 @@ module Omnibus
     end
 
     #
-    # Install the specified package
+    # Install the specified packages
     #
     # @return [void]
     #
-    def install(package, _)
-      `apt-get update && apt-get install -y --force-yes #{package}`
+    def install(packages, _)
+      `apt-get update && apt-get install -y --force-yes #{packages}`
     end
 
     #
-    # Remove the specified package
+    # Remove the specified packages
     #
     # @return [void]
     #
-    def remove(package)
-      `apt-get remove -y --force-yes #{package}`
+    def remove(packages)
+      `apt-get remove -y --force-yes #{packages}`
     end
 
   end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -530,11 +530,10 @@ module Omnibus
     def install(package, enablerepo)
       if null?(enablerepo)
         enablerepo_string = ''
-        `yum -y --disablerepo='*' --enablerepo='#{enablerepo}' install #{package}`
       else
-        enablerepo_string = "--enablerepo='#{enablerepo}'"
+        enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
       end
-      `yum -y --disablerepo='*' #{enablerepo_string} install #{package}`
+      `yum -y #{enablerepo_string} install #{package}`
     end
 
     #

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -527,7 +527,7 @@ module Omnibus
     #
     # @return [void]
     #
-    def install(packages, enablerepo)
+    def install(packages, enablerepo = NULL)
       if null?(enablerepo)
         enablerepo_string = ''
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -521,5 +521,29 @@ module Omnibus
         Ohai['kernel']['machine']
       end
     end
+
+        #
+    # Install the specified package
+    #
+    # @return [void]
+    #
+    def install(package, enablerepo)
+      if null?(enablerepo)
+        enablerepo_string = ''
+        `yum -y --disablerepo='*' --enablerepo='#{enablerepo}' install #{package}`
+      else
+        enablerepo_string = "--enablerepo='#{enablerepo}'"
+      end
+      `yum -y --disablerepo='*' #{enablerepo_string} install #{package}`
+    end
+
+    #
+    # Remove the specified package
+    #
+    # @return [void]
+    #
+    def remove(package)
+      `yum -y remove #{package}`
+    end
   end
 end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -533,6 +533,7 @@ module Omnibus
       else
         enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
       end
+      `yum check-update`
       `yum -y #{enablerepo_string} install #{packages}`
     end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -523,17 +523,17 @@ module Omnibus
     end
 
         #
-    # Install the specified package
+    # Install the specified packages
     #
     # @return [void]
     #
-    def install(package, enablerepo)
+    def install(packages, enablerepo)
       if null?(enablerepo)
         enablerepo_string = ''
       else
         enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
       end
-      `yum -y #{enablerepo_string} install #{package}`
+      `yum -y #{enablerepo_string} install #{packages}`
     end
 
     #
@@ -541,8 +541,8 @@ module Omnibus
     #
     # @return [void]
     #
-    def remove(package)
-      `yum -y remove #{package}`
+    def remove(packages)
+      `yum -y remove #{packages}`
     end
   end
 end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -617,7 +617,7 @@ module Omnibus
     # @return [Array<String>]
     #   the list of extended packages
     #
-    def extends_packages(packages, enablerepo)
+    def extends_packages(packages, enablerepo = NULL)
         extended_packages << [packages, enablerepo]
         extended_packages.dup
     end
@@ -952,7 +952,7 @@ module Omnibus
 
       # Install any package this project extends
       extended_packages.each do |packages, enablerepo|
-        puts "installing #{packages}"
+        log.info(log_key) { "installing #{packages}" }
         packager.install(packages, enablerepo)
       end
 
@@ -973,7 +973,7 @@ module Omnibus
 
       # Remove any package this project extends, after the health check ran
       extended_packages.each do |packages, _|
-        puts "removing #{packages}"
+        log.info(log_key) { "removing #{packages}" }
         packager.remove(packages)
       end
 


### PR DESCRIPTION
A package extension can be sumarized as running
`apt-get install package`
`build project`
`apt-get remove package`
`package project`

This means the project will require the package to be installed
to properly behave. Also, the project's package won't contain
any dependency already shipped with the extended package, thus
will be lighter.

## NB: this currently works with aptitude only

cc @remh, opened PR for discussion