### PR TITLE
Preserve file properties when syncing files

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -101,7 +101,7 @@ module Omnibus
             FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
           end
         when :file
-          FileUtils.cp(source_file, "#{destination}/#{relative_path}")
+          FileUtils.cp(source_file, "#{destination}/#{relative_path}", preserve: true)
         else
           raise RuntimeError,
             "Unknown file type: `File.ftype(source_file)' at `#{source_file}'!"


### PR DESCRIPTION
Allows us to preserve the modified time of `.py` files, thus the
corresponding `.pyc` files which are generated before the sync
stay valid.