### PR TITLE
[SDK] Support package extension

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -459,5 +459,28 @@ module Omnibus
         Ohai['kernel']['machine']
       end
     end
+
+    #
+    # Install the specified packages
+    #
+    # @return [void]
+    #
+    def install(packages, enablerepo = NULL)
+      if null?(enablerepo)
+        shellout!('apt-get update')
+      else
+        shellout!("apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{enablerepo}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'")
+      end
+      shellout!("apt-get install -y --force-yes #{packages}")
+    end
+
+    #
+    # Remove the specified packages
+    #
+    # @return [void]
+    #
+    def remove(packages)
+      shellout!("apt-get remove -y --force-yes #{packages}")
+    end
   end
 end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -594,5 +594,29 @@ module Omnibus
         Ohai['kernel']['machine']
       end
     end
+
+    #
+    # Install the specified packages
+    #
+    # @return [void]
+    #
+    def install(packages, enablerepo = NULL)
+      if null?(enablerepo)
+        enablerepo_string = ''
+      else
+        enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
+      end
+      shellout!('yum clean expire-cache')
+      shellout!("yum -y #{enablerepo_string} install #{packages}")
+    end
+
+    #
+    # Remove the specified package
+    #
+    # @return [void]
+    #
+    def remove(packages)
+      `yum -y remove #{packages}`
+    end
   end
 end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -619,6 +619,33 @@ module Omnibus
     end
     expose :runtime_dependency
 
+    # Add package(s) that this project extends.
+    #
+    # Use this to avoid packaging many files and libraries already included by
+    # the extended projects.
+    # This means that the project will rely on the extended packages to be
+    # installed to behave as expected.
+    # Extending a project is similar to running `apt-get install packages` before the
+    # project build, and `apt-get purge packages` before the packaging
+    #
+
+    # @example
+    #   extends_packages 'datadog-agent dd-check-mysql' 'datadog'
+    #
+    # @param [String] packages
+    #   the name of the extended packages
+    # @param [String] enablerepo
+    #   set if a specific repository needs to be enabled (`--enablerepo` for rpm)
+    #
+    # @return [Array<String>]
+    #   the list of extended packages
+    #
+    def extends_packages(packages, enablerepo = NULL)
+      extended_packages << [packages, enablerepo]
+      extended_packages.dup
+    end
+    expose :extends_packages
+
     #
     # Add a new exclusion pattern for a list of files or folders to exclude
     # when making the package.
@@ -807,6 +834,14 @@ module Omnibus
     #
     def runtime_dependencies
       @runtime_dependencies ||= []
+    end
+
+    # The list of packages this project extends.
+    #
+    # @return [Array<String>]
+    #
+    def extended_packages
+      @extended_packages ||= []
     end
 
     #
@@ -1002,6 +1037,12 @@ module Omnibus
       FileUtils.rm_rf(install_dir)
       FileUtils.mkdir_p(install_dir)
 
+      # Install any package this project extends
+      extended_packages.each do |packages, enablerepo|
+        log.info(log_key) { "installing #{packages}" }
+        packager.install(packages, enablerepo)
+      end
+
       softwares.each do |software|
         software.build_me
       end
@@ -1009,6 +1050,13 @@ module Omnibus
       write_json_manifest
       write_text_manifest
       HealthCheck.run!(self)
+
+      # Remove any package this project extends, after the health check ran
+      extended_packages.each do |packages, _|
+        log.info(log_key) { "removing #{packages}" }
+        packager.remove(packages)
+      end
+
       package_me
       compress_me
     end


### PR DESCRIPTION
A package extension can be sumarized as running
`apt-get install package`
`build project`
`apt-get remove package`
`package project`

This means the project will require the package to be installed
to properly behave. Also, the project's package won't contain
any dependency already shipped with the extended package, thus
will be lighter

NB: leaving windows and osx untouched for now