### PR TITLE
Fix RPM package for amazon linux EMR

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -277,10 +277,16 @@ module Omnibus
     # @return [String]
     #
     def mark_filesystem_directories(fsdir)
+      # Workaround for datadog-agent: do not list `filesystem` directories in the package because some packages
+      # installed by default on some distros have a complete disregard for the permissions defined by their
+      # own `filesystem` pkg, and then conflict with the datadog-agent pkg
+      # Example: the `service-nanny` pkg on Amazon Linux EMR, which defines `755` perms on `/usr/bin`
       if fsdir.eql?('/') || fsdir.eql?('/usr/bin') || fsdir.eql?('/usr/lib') || fsdir.eql?('/usr/share/empty')
-        return "%dir %attr(0555,root,root) #{fsdir}"
+        # return "%dir %attr(0555,root,root) #{fsdir}"
+        return ""
       elsif filesystem_directories.include?(fsdir)
-        return "%dir %attr(0755,root,root) #{fsdir}"
+        # return "%dir %attr(0755,root,root) #{fsdir}"
+        return ""
       else
         return "%dir #{fsdir}"
       end
@@ -307,6 +313,7 @@ module Omnibus
       # Get a list of all files
       files = FileSyncer.glob("#{build_dir}/**/*")
                 .map    { |path| build_filepath(path) }
+                .reject { |path| path.empty? }
 
       render_template(resource_path('spec.erb'),
         destination: spec_file,


### PR DESCRIPTION
Do not list `filesystem` directories in the package because some
packages installed by default on Amazon Linux EMR images have a complete
disregard for the permissions defined by their own `filesystem` pkg,
and then conflict with the datadog-agent pkg.

Example: `service-nanny` on Amazon Linux EMR 4.3.0:

```
$ rpm -lqv service-nanny | grep /usr/bin$
drwxr-xr-x    2 root    root                        0 Nov 25 02:16 /usr/bin
$ rpm -lqv filesystem | grep /usr/bin$
dr-xr-xr-x    2 root    root                        0 Jan  6  2012 /usr/bin
```

(notice the different permissions...)

So for EMR images  it's impossible to follow the RPM packaging
guidelines and list the directories owned by `filesystem` with the
correct permissions.

As an aside, we need to test the agent packaging on Amazon Linux prior to the releases to avoid having these problems in the future.