### PR TITLE
Add windows support

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -87,6 +87,21 @@ module Omnibus
     end
     expose :command
 
+    # Calls the embedded pip (Datadog specific function)
+    #
+    # @param [String] subcommand
+    #   the pip subcommand to execute
+    #
+    # @return [void]
+    def pip(subcommand, options = {})
+     pip_path = "\"#{install_dir}/embedded/bin/pip\""
+     if Ohai['platform'] == "windows"
+       pip_path = "\"#{windows_safe_path(install_dir)}\\embedded\\Scripts\\pip.exe\""
+     end
+     command("#{pip_path} #{subcommand}", options)
+    end
+    expose :pip
+
     #
     # Execute the given make command. When present, this method will prefer the
     # use of +gmake+ over +make+. If applicable, this method will also set

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -276,7 +276,7 @@ module Omnibus
         compression_switch = 'J' if downloaded_file.end_with?('xz')
         compression_switch = ''  if downloaded_file.end_with?('tar')
 
-        "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C#{Config.source_dir}"
+        "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C #{Config.source_dir} --force-local"
       end
     end
 

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -276,7 +276,7 @@ module Omnibus
         compression_switch = 'J' if downloaded_file.end_with?('xz')
         compression_switch = ''  if downloaded_file.end_with?('tar')
 
-        "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C #{Config.source_dir} --force-local"
+        "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C #{Config.source_dir}"
       end
     end
 

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -64,7 +64,7 @@ module Omnibus
         false
       else
         create_directory(File.dirname(cache_path))
-        shellout!("git --git-dir=#{cache_path} init -q")
+        shellout!(%Q(git --git-dir="#{cache_path}" init -q))
         true
       end
     end
@@ -113,15 +113,15 @@ module Omnibus
       create_cache_path
       remove_git_dirs
 
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} add -A -f))
+      shellout!(%Q(git --git-dir="#{cache_path}" --work-tree="#{install_dir}" add -A -f))
 
       begin
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{tag}"))
+        shellout!(%Q(git --git-dir="#{cache_path}" --work-tree="#{install_dir}" commit -q -m "Backup of #{tag}"))
       rescue CommandFailed => e
         raise unless e.message.include?('nothing to commit')
       end
 
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f "#{tag}"))
+      shellout!(%Q(git --git-dir="#{cache_path}" --work-tree="#{install_dir}" tag -f "#{tag}"))
     end
 
     def restore
@@ -129,7 +129,7 @@ module Omnibus
 
       create_cache_path
 
-      cmd = shellout(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{tag}"))
+      cmd = shellout(%Q(git --git-dir="#{cache_path}" --work-tree="#{install_dir}" tag -l "#{tag}"))
 
       restore_me = false
       cmd.stdout.each_line do |line|
@@ -138,7 +138,7 @@ module Omnibus
 
       if restore_me
         log.internal(log_key) { "Detected tag `#{tag}' can be restored, restoring" }
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{tag}"))
+        shellout!(%Q(git --git-dir="#{cache_path}" --work-tree="#{install_dir}" checkout -f "#{tag}"))
         true
       else
         log.internal(log_key) { "Could not find tag `#{tag}', skipping restore" }

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -198,6 +198,7 @@ module Omnibus
           when '5.1.2600', 'xp'     then 'xp'
           when '5.2.3790', '2003r2' then '2003r2'
           when '6.0.6001', '2008'   then '2008'
+          when '6.0.6002', '2008'   then '2008'
           when '6.1.7600', '7'      then '7'
           when '6.1.7601', '2008r2' then '2008r2'
           when '6.2.9200', '8'      then '8'

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -58,18 +58,49 @@ module Omnibus
       # If fastmsi, zip up the contents of the install directory
       shellout!(zip_command) if fast_msi
 
+      # If there are extra package files let's Harvest them hard
+      dir_refs = []
+      candle_vars = ''
+      wxs_list = ''
+      wixobj_list = ''
+      if File.directory?("#{Config.source_dir}\\OMNIBUS_EXTRA_PACKAGE_FILES")
+        # Let's collect the DirectoryRefs
+        Dir.foreach("#{Config.source_dir}\\OMNIBUS_EXTRA_PACKAGE_FILES") do |item|
+          next if item == '.' or item == '..'
+          dir_refs.push(item)
+        end
+      end
+
       # Harvest the files with heat.exe, recursively generate fragment for
       # project directory
       Dir.chdir(staging_dir) do
         shellout!(heat_command)
 
+        # Let's also harvest our extras
+        dir_refs.each do |dirref|
+          shellout! <<-EOH.split.join(' ').squeeze(' ').strip
+            heat.exe dir
+              "#{windows_safe_path("#{Config.source_dir}\\OMNIBUS_EXTRA_PACKAGE_FILES\\#{dirref}")}"
+              -nologo -srd -gg -cg Extra#{dirref}
+              -dr #{dirref}
+              -var "var.Extra#{dirref}"
+              -out "extra-#{dirref}.wxs"
+          EOH
+
+          candle_vars += "-dExtra#{dirref}=\""\
+            "#{windows_safe_path("#{Config.source_dir}\\OMNIBUS_EXTRA_PACKAGE_FILES\\#{dirref}")}"\
+            "\" "
+          wxs_list += "extra-#{dirref}.wxs "
+          wixobj_list += "extra-#{dirref}.wixobj "
+        end
+
         # Compile with candle.exe
-        shellout!(candle_command)
+        shellout!(candle_command(candle_vars: candle_vars, wxs_list: wxs_list))
 
         # Create the msi, ignoring the 204 return code from light.exe since it is
         # about some expected warnings
         msi_file = windows_safe_path(Config.package_dir, msi_name)
-        shellout!(light_command(msi_file), returns: [0, 204])
+        shellout!(light_command(msi_file, wixobj_list: wixobj_list), returns: [0, 204])
 
         if signing_identity
           sign_package(msi_file)
@@ -519,7 +550,7 @@ module Omnibus
     #
     # @return [String]
     #
-    def candle_command(is_bundle: false)
+    def candle_command(is_bundle: false, candle_vars: '', wxs_list: '')
       if is_bundle
         <<-EOH.split.join(' ').squeeze(' ').strip
         candle.exe
@@ -536,7 +567,10 @@ module Omnibus
             -nologo
             #{wix_candle_flags}
             #{wix_extension_switches(wix_candle_extensions)}
-            -dProjectSourceDir="#{windows_safe_path(project.install_dir)}" "project-files.wxs"
+            -dProjectSourceDir="#{windows_safe_path(project.install_dir)}"
+            #{candle_vars}
+            "project-files.wxs"
+            #{wxs_list}
             "#{windows_safe_path(staging_dir, 'source.wxs')}"
         EOH
       end
@@ -547,7 +581,7 @@ module Omnibus
     #
     # @return [String]
     #
-    def light_command(out_file, is_bundle: false)
+    def light_command(out_file, is_bundle: false, wixobj_list: '')
       if is_bundle
         <<-EOH.split.join(' ').squeeze(' ').strip
         light.exe
@@ -568,7 +602,7 @@ module Omnibus
             #{wix_extension_switches(wix_light_extensions)}
             -cultures:en-us
             -loc "#{windows_safe_path(staging_dir, 'localization-en-us.wxl')}"
-            project-files.wixobj source.wixobj
+            project-files.wixobj #{wixobj_list} source.wixobj
             -out "#{out_file}"
         EOH
       end


### PR DESCRIPTION
This PR adds a few Datadog-specific patches for Omnibus to build the Windows agent.
@elafarge is the main author of this PR, I updated it for omnibus 5.0, fixed a couple things and rebased.

## Previous state
Omnibus 5.0 not tested with Windows.

## What does this PR do ?
Add the ability to ship extra files in the final MSI.

Fix an issue with spaces in path and tar on Windows.

Add a `pip` DSL. (because it's easier and more beautiful to use)

## Does it affect other platforms ?
`pip` DSL (see omnibus-software)

## Related PR
https://github.com/DataDog/dd-agent/pull/2417
https://github.com/DataDog/dd-agent-omnibus/pull/74
https://github.com/DataDog/omnibus-software/pull/48
https://github.com/DataDog/osx-dd-agent-build-box/pull/1