### PR TITLE
Extra files may be removed during the agent uninstall process

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -626,7 +626,7 @@ module Omnibus
     # This means that the project will rely on the extended packages to be
     # installed to behave as expected.
     # Extending a project is similar to running `apt-get install packages` before the
-    # project build, and `apt-get purge packages` before the packaging
+    # project build, and `apt-get remove packages` before the packaging
     #
 
     # @example


### PR DESCRIPTION
This is ugly, but it will stop extra files from being removed when the agent is uninstalled, by moving them to another location temporarily.