### PR TITLE
adds suse to packager

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -38,6 +38,7 @@ module Omnibus
       'fedora'   => RPM,
       'rhel'     => RPM,
       'wrlinux'  => RPM,
+      'suse'     => RPM,
       'aix'      => BFF,
       'solaris2' => Solaris,
       'windows'  => MSI,


### PR DESCRIPTION
SUSE requires an RPM, adding this to the hash will allow omnibus to correctly determine what it needs to build.