### PR TITLE
fixes intermittent nil error on downloads

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -177,7 +177,7 @@ module Omnibus
         progress_bar.total = total
       }
       options[:progress_proc] = ->(step) {
-        downloaded_amount = [step, reported_total].min
+        downloaded_amount = reported_total ? [step, reported_total].min : step
         progress_bar.progress = downloaded_amount
       }
 


### PR DESCRIPTION
There's an intermittent nil error that occurs on fetching sometimes, this fix was applied upstream to solve it (https://github.com/chef/omnibus/pull/691), and it will solve it here as well. The error trace is below:


```
====/usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/fetchers/net_fetcher.rb:180:in `each': comparison of NilClass with 13843 failed (ArgumentError)
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/fetchers/net_fetcher.rb:180:in `min'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/fetchers/net_fetcher.rb:180:in `block in download'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:331:in `call'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:331:in `block (3 levels) in open_http'
	from /usr/lib64/ruby/2.1.0/net/protocol.rb:411:in `call_block'
	from /usr/lib64/ruby/2.1.0/net/protocol.rb:402:in `<<'
	from /usr/lib64/ruby/2.1.0/net/protocol.rb:102:in `read'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:313:in `read_chunked'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:276:in `block in read_body_0'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:250:in `inflater'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:274:in `read_body_0'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:201:in `read_body'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:328:in `block (2 levels) in open_http'
	from /usr/lib64/ruby/2.1.0/net/http.rb:1415:in `block (2 levels) in transport_request'
	from /usr/lib64/ruby/2.1.0/net/http/response.rb:162:in `reading_body'
	from /usr/lib64/ruby/2.1.0/net/http.rb:1414:in `block in transport_request'
	from /usr/lib64/ruby/2.1.0/net/http.rb:1405:in `catch'
	from /usr/lib64/ruby/2.1.0/net/http.rb:1405:in `transport_request'
	from /usr/lib64/ruby/2.1.0/net/http.rb:1378:in `request'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:319:in `block in open_http'
	from /usr/lib64/ruby/2.1.0/net/http.rb:853:in `start'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:313:in `open_http'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:724:in `buffer_open'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:210:in `block in open_loop'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:208:in `catch'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:208:in `open_loop'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:149:in `open_uri'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/core_extensions/open_uri.rb:51:in `open_uri'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:704:in `open'
	from /usr/lib64/ruby/2.1.0/open-uri.rb:34:in `open'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/fetchers/net_fetcher.rb:184:in `download'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/fetchers/net_fetcher.rb:82:in `fetch'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/software.rb:679:in `fetch'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/project.rb:1031:in `block (3 levels) in download'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:64:in `call'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:64:in `block (4 levels) in initialize'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:62:in `loop'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:62:in `block (3 levels) in initialize'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:61:in `catch'
	from /usr/lib64/ruby/gems/2.1.0/bundler/gems/omnibus-ruby-4f2d154c2ed0/lib/omnibus/thread_pool.rb:61:in `block (2 levels) in initialize'
```