### PR TITLE
[net_fetcher] Don't preserve ownership of files when extracting tars

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -276,7 +276,7 @@ module Omnibus
         compression_switch = 'J' if downloaded_file.end_with?('xz')
         compression_switch = ''  if downloaded_file.end_with?('tar')
 
-        "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C#{Config.source_dir}"
+        "#{tar} #{compression_switch}xfo #{windows_safe_path(downloaded_file)} -C#{Config.source_dir}"
       end
     end
 


### PR DESCRIPTION
If the files are owned by a high user ID (typically > 65536) then on
some environments (for instance in docker containers running on
CircleCI) the extraction fails.

Example of such an error:

```
<filename>: Cannot change ownership to uid <high_UID>, gid 5000: Invalid argument
```

To fix this, don't preserve file ownership when extracting tars by
using the `o` option of tar. Reference on this option: [GNU tar man page](https://www.gnu.org/software/tar/manual/html_section/tar_22.html#g_t_002d_002dno_002dsame_002downer)