### PR TITLE
fixes package extension

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1107,6 +1107,8 @@ module Omnibus
       FileUtils.rm_rf(install_dir)
       FileUtils.mkdir_p(install_dir)
 
+      packager = packagers_for_system[0]
+
       # Install any package this project extends
       extended_packages.each do |packages, enablerepo|
         log.info(log_key) { "installing #{packages}" }


### PR DESCRIPTION
package extension is broken because it now allows multiple packagers.

Package extension is used in the integration sdk to include the various files that we use in the agent, but it's broken because there are multiple packagers now allowed. However, all of the omnibus only have one packager at the moment.