### PR TITLE
[Windows] Fix bundle signing

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -138,7 +138,7 @@ module Omnibus
           shellout!(light_command(bundle_file, is_bundle: true), returns: [0, 204])
 
           if signing_identity
-            sign_package(bundle_file)
+            sign_package(bundle_file, is_bundle: true)
           end
         end
       end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -111,8 +111,25 @@ module Omnibus
     # the file with with each server, stopping after the first to succeed.
     # If none succeed, an exception is raised.
     #
-    def sign_package(package_file)
+    def sign_package(package_file, is_bundle: false )
       success = false
+
+      if is_bundle
+        cmd = Array.new.tap do |arr|
+          arr << "insignia.exe"
+          arr << "-ib \"#{package_file}\""
+          arr << "-o engine.exe"
+        end.join(" ")
+        shellout(cmd)
+        sign_package("engine.exe", is_bundle: false)
+        cmd = Array.new.tap do |arr|
+          arr << "insignia.exe"
+          arr << "-ab engine.exe \"#{package_file}\""
+          arr << "-o \"#{package_file}\""
+        end.join(" ")
+        shellout(cmd)
+      end
+
       timestamp_servers.each do |ts|
         success = try_sign(package_file, ts)
         break if success


### PR DESCRIPTION
### Description

Bundle signing wasn't implemented properly.  The  bundle engine needs to be extracted and signed separately, otherwise the package is invalid and is treated as if it has a bad signature.