### PR TITLE
[git_fetcher] Add option to always fetch tags from remote

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -23,7 +23,7 @@ module Omnibus
     # @return [true, false]
     #
     def fetch_required?
-      !(cloned? && contains_revision?(resolved_version) && !always_fetch_tags?)
+      !(cloned? && contains_revision?(resolved_version)) || always_fetch_tags?
     end
 
     #

--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -18,12 +18,12 @@ module Omnibus
   class GitFetcher < Fetcher
     #
     # A fetch is required if the git repository is not cloned or if the local
-    # revision does not match the desired revision.
+    # revision does not match the desired revision or if we always fetch tags
     #
     # @return [true, false]
     #
     def fetch_required?
-      !(cloned? && contains_revision?(resolved_version))
+      !(cloned? && contains_revision?(resolved_version) && !always_fetch_tags?)
     end
 
     #
@@ -63,6 +63,7 @@ module Omnibus
 
       if cloned?
         git_fetch
+        git_fetch_tags if always_fetch_tags?
       else
         force_recreate_project_dir! unless dir_empty?(project_dir)
         git_clone
@@ -106,6 +107,15 @@ module Omnibus
     #
     def clone_submodules?
       source[:submodules] || false
+    end
+
+    #
+    # Determine if we should always fetch tags
+    #
+    # @return [true, false]
+    #
+    def always_fetch_tags?
+      source[:always_fetch_tags] || false
     end
 
     #
@@ -163,8 +173,22 @@ module Omnibus
     # @return [void]
     #
     def git_fetch
-      fetch_cmd = "fetch #{source_url} #{described_version} --tags"
+      fetch_cmd = "fetch #{source_url} #{described_version}"
       fetch_cmd << " --recurse-submodules=on-demand" if clone_submodules?
+      git(fetch_cmd)
+    end
+
+    #
+    # Force-fetch the tags from the remote
+    # We do this in a separate step on top of `git_fetch` because until v1.9 of git, `git fetch`
+    # was not a strict subset of `git fetch --tags`: doing only `git fetch --tags` doesn't
+    # guarantee that the latest commits are actually fetched.
+    # Merge with `git_fetch` once git >= v1.9 is used on all our build images.
+    #
+    # @return [void]
+    #
+    def git_fetch_tags
+      fetch_cmd = "fetch #{source_url} #{described_version} --tags"
       git(fetch_cmd)
     end
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -295,6 +295,8 @@ module Omnibus
     #
     # @option val [Boolean] :submodules (false)
     #   clone git submodules
+    # @option val [Boolean] :always_fetch_tags (false)
+    #   always fetch tags from the remote, useful if the version of the project is determined from this software
     #
     # If multiple checksum types are provided, only the strongest will be used.
     #
@@ -314,7 +316,7 @@ module Omnibus
           :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, # used by net_fetcher
           :options, # used by path_fetcher
-          :submodules # used by git_fetcher
+          :submodules, :always_fetch_tags # used by git_fetcher
         ]
         unless extra_keys.empty?
           raise InvalidValue.new(:source,


### PR DESCRIPTION
Using this option ensures that whatever version of git is used, we
consistently pull the tags in all cases (even when the latest local
commit is up-to-date with the remote but doesn't have a remote tag).

When the option is set, we fetch tags in a separate git command
because until git v1.9 `git fetch` was not a strict subset of
`git fetch --tags` (see http://stackoverflow.com/a/20608181 for more
details). When we get rid of older versions of git, we'll be able
to only use `git fetch --tags`.

