### PR TITLE
allow zypper to be used to install a package in package extension

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -648,9 +648,9 @@ module Omnibus
     #
     def remove(packages)
       if ohai["platform_family"] == 'suse'
-        `zypper remove -y #{packages}`
+        shellout!("zypper remove -y #{packages}")
       else
-        `yum -y remove #{packages}`
+        shellout!("yum -y remove #{packages}")
       end
     end
   end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -626,7 +626,7 @@ module Omnibus
     # @return [void]
     #
     def install(packages, enablerepo = NULL)
-      if ohai["platform_family"] == 'suse'
+      if Ohai["platform_family"] == 'suse'
         log.info('enablerepo only works on yum based systems, not on zypper based ones')
         shellout!('zypper clean')
         shellout!("zypper install -y #{packages}")

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -626,13 +626,19 @@ module Omnibus
     # @return [void]
     #
     def install(packages, enablerepo = NULL)
-      if null?(enablerepo)
-        enablerepo_string = ''
+      if ohai["platform_family"] == 'suse'
+        log.info('enablerepo only works on yum based systems, not on zypper based ones')
+        shellout!('zypper clean')
+        shellout!("zypper install -y #{packages}")
       else
-        enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
+        if null?(enablerepo)
+          enablerepo_string = ''
+        else
+          enablerepo_string = "--disablerepo='*' --enablerepo='#{enablerepo}'"
+        end
+        shellout!('yum clean expire-cache')
+        shellout!("yum -y #{enablerepo_string} install #{packages}")
       end
-      shellout!('yum clean expire-cache')
-      shellout!("yum -y #{enablerepo_string} install #{packages}")
     end
 
     #
@@ -641,7 +647,11 @@ module Omnibus
     # @return [void]
     #
     def remove(packages)
-      `yum -y remove #{packages}`
+      if ohai["platform_family"] == 'suse'
+        `zypper remove -y #{packages}`
+      else
+        `yum -y remove #{packages}`
+      end
     end
   end
 end


### PR DESCRIPTION
SLES uses zypper but extensions were only set up to use yum. This will enable zypper as well