### PR TITLE
Gets suse install to work

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,10 +630,26 @@ module Omnibus
         log.info(log_key) do
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
-        shellout!('zypper ms -d -a')
-        shellout!('zypper clean')
-        shellout!('zypper refresh')
-        shellout!("zypper install -y --repo #{enablerepo} #{packages}")
+        log.info(log_key) do
+          'zypper ms -d -a'
+          shellout!('zypper ms -d -a')
+        end
+        log.info(log_key) do
+          'zypper clean'
+          shellout!('zypper clean')
+        end
+        log.info(log_key) do
+          "zypper mr -e #{enablerepo}"
+          shellout!("zypper mr -e #{enablerepo}")
+        end
+        log.info(log_key) do
+          'zypper refresh'
+          shellout!('zypper refresh')
+        end
+        log.info(log_key) do
+          "zypper install -y --repo #{enablerepo} #{packages}"
+          shellout!("zypper install -y --repo #{enablerepo} #{packages}")
+        end
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -633,23 +633,23 @@ module Omnibus
         log.info(log_key) do
           'zypper ms -d -a'
         end
-        shellout!('zypper ms -d -a')
+        shellout!('zypper --non-interactive --no-gpg-checks ms -d -a')
         log.info(log_key) do
           'zypper clean'
         end
-        shellout!('zypper clean')
+        shellout!('zypper --non-interactive --no-gpg-checks clean')
         log.info(log_key) do
           "zypper mr -e #{enablerepo}"
         end
-        shellout!("zypper mr -e #{enablerepo}")
+        shellout!("zypper --non-interactive --no-gpg-checks mr -e #{enablerepo}")
         log.info(log_key) do
           'zypper refresh'
         end
-        shellout!('zypper refresh')
+        shellout!('zypper --non-interactive --no-gpg-checks refresh')
         log.info(log_key) do
           "zypper install -y --repo #{enablerepo} #{packages}"
         end
-        shellout!("zypper install -y --repo #{enablerepo} #{packages}")
+        shellout!("zypper --non-interactive --no-gpg-checks install -y --repo #{enablerepo} #{packages}")
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -633,23 +633,23 @@ module Omnibus
         log.info(log_key) do
           'zypper ms -d -a'
         end
-        shellout!('zypper --non-interactive --no-gpg-checks ms -d -a')
+        shellout!('zypper --non-interactive --no-gpg-checks ms -d -a || true')
         log.info(log_key) do
           'zypper clean'
         end
-        shellout!('zypper --non-interactive --no-gpg-checks clean')
+        shellout!('zypper --non-interactive --no-gpg-checks clean || true')
         log.info(log_key) do
           "zypper mr -e #{enablerepo}"
         end
-        shellout!("zypper --non-interactive --no-gpg-checks mr -e #{enablerepo}")
+        shellout!("zypper --non-interactive --no-gpg-checks mr -e #{enablerepo} || true")
         log.info(log_key) do
           'zypper refresh'
         end
-        shellout!('zypper --non-interactive --no-gpg-checks refresh')
+        shellout!('zypper --non-interactive --no-gpg-checks refresh || true')
         log.info(log_key) do
           "zypper install -y --repo #{enablerepo} #{packages}"
         end
-        shellout!("zypper --non-interactive --no-gpg-checks --no-refresh install -y --repo #{enablerepo} #{packages}")
+        shellout!("zypper --non-interactive --no-gpg-checks --no-refresh install -y --repo #{enablerepo} #{packages} || true")
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -632,7 +632,7 @@ module Omnibus
         end
         shellout!('zypper ms -d -a')
         shellout!('zypper clean')
-        shellout!("zypper install -y #{enablerepo}:#{packages}")
+        shellout!("zypper install -y --repo #{enablerepo} #{packages}")
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -649,7 +649,7 @@ module Omnibus
     # @return [void]
     #
     def remove(packages)
-      if ohai["platform_family"] == 'suse'
+      if Ohai["platform_family"] == 'suse'
         shellout!("zypper remove -y #{packages}")
       else
         shellout!("yum -y remove #{packages}")

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,8 +630,10 @@ module Omnibus
         log.info(log_key) do
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
+        shellout!('sudo zypper ms -d -a')
         shellout!('zypper clean')
-        shellout!("zypper install -y #{packages} --repo #{enablerepo}")
+        shellout!("zypper install -y #{enablerepo}:#{packages}")
+        shellout!('sudo zypper ms -e -a')
       else
         if null?(enablerepo)
           enablerepo_string = ''
@@ -650,7 +652,9 @@ module Omnibus
     #
     def remove(packages)
       if Ohai["platform_family"] == 'suse'
+        shellout!('sudo zypper ms -d -a')
         shellout!("zypper remove -y #{packages}")
+        shellout!('sudo zypper ms -e -a')
       else
         shellout!("yum -y remove #{packages}")
       end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -649,7 +649,7 @@ module Omnibus
         log.info(log_key) do
           "zypper install -y --repo #{enablerepo} #{packages}"
         end
-        shellout!("zypper --non-interactive --no-gpg-checks install -y --repo #{enablerepo} #{packages}")
+        shellout!("zypper --non-interactive --no-gpg-checks --no-refresh install -y --repo #{enablerepo} #{packages}")
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,10 +630,10 @@ module Omnibus
         log.info(log_key) do
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
-        shellout!('zypper ms -d -a')
+        # shellout!('zypper ms -d -a')
         shellout!('zypper clean')
         shellout!("zypper install -y --repo #{enablerepo} #{packages}")
-        shellout!('zypper ms -e -a')
+        # shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)
           enablerepo_string = ''

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -632,24 +632,24 @@ module Omnibus
         end
         log.info(log_key) do
           'zypper ms -d -a'
-          shellout!('zypper ms -d -a')
         end
+        shellout!('zypper ms -d -a')
         log.info(log_key) do
           'zypper clean'
-          shellout!('zypper clean')
         end
+        shellout!('zypper clean')
         log.info(log_key) do
           "zypper mr -e #{enablerepo}"
-          shellout!("zypper mr -e #{enablerepo}")
         end
+        shellout!("zypper mr -e #{enablerepo}")
         log.info(log_key) do
           'zypper refresh'
-          shellout!('zypper refresh')
         end
+        shellout!('zypper refresh')
         log.info(log_key) do
           "zypper install -y --repo #{enablerepo} #{packages}"
-          shellout!("zypper install -y --repo #{enablerepo} #{packages}")
         end
+        shellout!("zypper install -y --repo #{enablerepo} #{packages}")
         shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -631,7 +631,7 @@ module Omnibus
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
         shellout!('zypper clean')
-        shellout!("zypper install -y #{packages}")
+        shellout!("zypper install -y #{packages} --repo #{enablerepo}")
       else
         if null?(enablerepo)
           enablerepo_string = ''

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,10 +630,10 @@ module Omnibus
         log.info(log_key) do
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
-        shellout!('sudo zypper ms -d -a')
+        shellout!('zypper ms -d -a')
         shellout!('zypper clean')
         shellout!("zypper install -y #{enablerepo}:#{packages}")
-        shellout!('sudo zypper ms -e -a')
+        shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)
           enablerepo_string = ''
@@ -652,9 +652,9 @@ module Omnibus
     #
     def remove(packages)
       if Ohai["platform_family"] == 'suse'
-        shellout!('sudo zypper ms -d -a')
+        shellout!('zypper ms -d -a')
         shellout!("zypper remove -y #{packages}")
-        shellout!('sudo zypper ms -e -a')
+        shellout!('zypper ms -e -a')
       else
         shellout!("yum -y remove #{packages}")
       end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,10 +630,11 @@ module Omnibus
         log.info(log_key) do
           'enablerepo only works on yum based systems, not on zypper based ones'
         end
-        # shellout!('zypper ms -d -a')
+        shellout!('zypper ms -d -a')
         shellout!('zypper clean')
+        shellout!('zypper refresh')
         shellout!("zypper install -y --repo #{enablerepo} #{packages}")
-        # shellout!('zypper ms -e -a')
+        shellout!('zypper ms -e -a')
       else
         if null?(enablerepo)
           enablerepo_string = ''


### PR DESCRIPTION
This is very ugly, however it's necessary. The install does not work, since the docker image does not have some of the files we depend upon for the datadog agent to work. It installs, it just fails when it tries to start. So, we have to do an `|| true`. It's really ugly, but there's no other solution for now.