### PR TITLE
Allow signfiles list to be empty

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -79,9 +79,12 @@ module Omnibus
           sign_package(signfile)
         end
         puts "additional signing files"
-        additional_sign_files.each do |signfile|
-          puts "signing #{signfile}"
-          sign_package(signfile)
+
+        if additional_sign_files
+            additional_sign_files.each do |signfile|
+            puts "signing #{signfile}"
+            sign_package(signfile)
+            end
         end
 
       end


### PR DESCRIPTION
Previous checkin allowed package to specify list of files to be signed.  However, caused an error if the package didn't specify a list.  This PR fixes that; allows the list to be empty

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
