### PR TITLE
[windows] remove wildcard signing.  Was resulting in some binaries (not

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -68,18 +68,8 @@ module Omnibus
     end
 
     build do
-      puts "starting signing"
       if signing_identity
-        Dir["#{install_dir}" + "/bin/**/*.exe"].each do |signfile|
-          puts "signing #{signfile}"
-          sign_package(signfile)
-        end
-
-        Dir["#{install_dir}" + "/dist/**/*.exe"].each do |signfile|
-          sign_package(signfile)
-        end
-        puts "additional signing files"
-
+        puts "starting signing"
         if additional_sign_files
             additional_sign_files.each do |signfile|
             puts "signing #{signfile}"


### PR DESCRIPTION
ours) being signed by us.

### Description

Was signing all EXEs in installdir/bin and installdir/dist.  This was missing some files, and resulted in signing some files that were redistributed (shouldn't be signed).  Remove the wildcard altogether, and just sign the explicit list of files.