### PR TITLE
Pin ffi

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "license_scout"
   gem.add_dependency 'httparty'
+  # Pin ffi (dep of ohai) to a version that can be compiled with older autoconfs
+  gem.add_dependency "ffi",              "1.9.18"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"


### PR DESCRIPTION
Pin ffi to version that works with older `autoconf`s.

It's a compiled dep that requires autoconf 2.68+ since the latest
version. Pin to the previous version for compatibility with autoconf 2.63 that's
installed in our centos build image.
