### PR TITLE
Better S3 Caching

### DIFF
--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -70,6 +70,10 @@ module Omnibus
       desc: "Use the given manifest when downloading software sources.",
       type: :string,
       default: nil
+    method_option :populate_s3_cache,
+      desc: "Populate the S3 cache.",
+      type: :boolean,
+      default: false
     desc "build PROJECT", "Build the given Omnibus project"
     def build(name)
       manifest = if @options[:use_manifest]
@@ -80,6 +84,7 @@ module Omnibus
 
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
+      Omnibus::S3Cache.populate if @options[:populate_s3_cache] && !Omnibus::S3Cache.fetch_missing.empty?
       project.download
       project.build
 

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -279,15 +279,33 @@ module Omnibus
     #
     # @return [String]
     default(:s3_access_key) do
-      raise MissingRequiredAttribute.new(self, :s3_access_key, "'ABCD1234'")
+      if s3_profile || s3_role || s3_instance_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :s3_access_key, "'ABCD1234'")
+      end
     end
 
     # The S3 secret key to use with S3 caching.
     #
     # @return [String]
     default(:s3_secret_key) do
-      raise MissingRequiredAttribute.new(self, :s3_secret_key, "'EFGH5678'")
+      if s3_profile || s3_role || s3_instance_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :s3_secret_key, "'EFGH5678'")
+      end
     end
+
+    # The AWS credentials profile to use with S3 caching.
+    #
+    # @return [String, nil]
+    default(:s3_profile, nil)
+
+    # The path where the AWS credentials file can be found for the S3 caching profile
+    #
+    # @return [String, nil]
+    default(:s3_credentials_file_path, nil)
 
     # The region of the S3 bucket you want to cache software artifacts in.
     # Defaults to 'us-east-1'
@@ -296,6 +314,67 @@ module Omnibus
     default(:s3_region) do
       "us-east-1"
     end
+
+    # The HTTP or HTTPS endpoint to send requests to, when using non-standard endpoint
+    #
+    # @return [String, nil]
+    default(:s3_endpoint, nil)
+
+    # Use path style URLs instead of subdomains for S3 URLs
+    #
+    # @return [true, false]
+    default(:s3_force_path_style, false)
+
+    # Enable or disable S3 Accelerate support
+    #
+    # @return [true, false]
+    default(:s3_accelerate, false)
+
+    # Use a role with S3 caching
+    #
+    # @return [true, false]
+    default(:s3_role, false)
+
+    # The arn to use with the role
+    #
+    # @return [String, nil]
+    default(:s3_role_arn, nil)
+
+    # The session name to use with the role
+    #
+    # @return [String, nil]
+    default(:s3_role_session_name, nil)
+
+    # Use a profile to authenticate the role change
+    #
+    # @return [true, false]
+    default(:s3_sts_creds_profile, false)
+
+    # Use the ECS credentials to authenticate the role change
+    #
+    # @return [true, false]
+    default(:s3_sts_creds_ecs_credentials, false)
+
+    # Use an instance profile to authenticate the role change
+    #
+    # @return [true, false]
+    default(:s3_sts_creds_instance_profile, false)
+
+    # Use the instance profile to connect to s3
+    #
+    # @return [true, false]
+    default(:s3_instance_profile, false)
+
+    # S3 Authenticated Download
+    #
+    # @return [true, false]
+    default(:s3_authenticated_download, false)
+
+    # S3 use ECS instance credentials provider
+    #
+    # @return [true, false]
+    default(:s3_ecs_credentials, false)
+
 
     # --------------------------------------------------
     # @!endgroup

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -15,6 +15,8 @@
 #
 
 require "aws-sdk"
+require "aws-sdk-core/credentials"
+require "aws-sdk-core/shared_credentials"
 require "base64"
 
 module Omnibus
@@ -32,10 +34,11 @@ module Omnibus
       #
       # @example
       #   {
-      #     region:               'us-east-1',
-      #     access_key_id:        Config.s3_access_key,
-      #     secret_access_key:    Config.s3_secret_key,
-      #     bucket_name:          Config.s3_bucket
+      #     region:                   'us-east-1',
+      #     bucket_name:              Config.s3_bucket,
+      #     endpoint:                 Config.s3_endpoint,
+      #     use_accelerate_endpoint:  Config.s3_accelerate
+      #     force_path_style:         Config.s3_force_path_style
       #   }
       #
       # @return [Hash<String, String>]
@@ -50,11 +53,70 @@ module Omnibus
       # @return [Aws::S3::Resource]
       #
       def client
-        @s3_client ||= Aws::S3::Resource.new(
-          region:            s3_configuration[:region],
-          access_key_id:     s3_configuration[:access_key_id],
-          secret_access_key: s3_configuration[:secret_access_key]
-        )
+        # Update the region before grabbing credentials,
+        # in case the credential type needs the region
+        Aws.config.update(region: s3_configuration[:region])
+        Aws.config.update(credentials: get_credentials)
+
+        @s3_client ||= Aws::S3::Resource.new(resource_params)
+      end
+
+      #
+      # S3 Resource Parameters
+      #
+      # @return [Hash]
+      #
+      def resource_params
+        params = {
+          use_accelerate_endpoint:  s3_configuration[:use_accelerate_endpoint],
+          force_path_style: s3_configuration[:force_path_style],
+          region: s3_configuration[:region],
+        }
+
+        if s3_configuration[:use_accelerate_endpoint]
+          params[:endpoint] = "https://s3-accelerate.amazonaws.com"
+        end
+
+        if s3_configuration[:endpoint]
+          params[:endpoint] = s3_configuration[:endpoint]
+        end
+
+        if s3_configuration[:retry_limit]
+          params[:retry_limit] = s3_configuration[:retry_limit]
+        end
+
+        params
+      end
+
+      #
+      # Create credentials object based on credential profile or access key
+      # parameters for use by the client object.
+      #
+      # @return [Aws::SharedCredentials, Aws::Credentials]
+      def get_credentials(sts_client_credentials=false)
+        if s3_configuration[:role] && !sts_client_credentials
+          # The region must be set in order for Aws::STS::Client to be created
+          Aws::AssumeRoleCredentials.new(
+            client: Aws::STS::Client.new(
+              region: s3_configuration[:region],
+              credentials: get_credentials(sts_client_credentials=true),
+            ),
+            region: s3_configuration[:region],
+            role_arn: s3_configuration[:role_arn],
+            role_session_name: s3_configuration[:role_session_name]
+          )
+        elsif s3_configuration[:profile] || (sts_client_credentials && s3_configuration[:sts_creds_profile])
+          Aws::SharedCredentials.new(
+            profile_name: s3_configuration[:profile],
+            path: s3_configuration[:credentials_file_path]
+          )
+        elsif s3_configuration[:ecs_credentials] || (sts_client_credentials && s3_configuration[:sts_creds_ecs_credentials])
+          Aws::ECSCredentials.new()
+        elsif s3_configuration[:instance_profile] || (sts_client_credentials && s3_configuration[:sts_creds_instance_profile])
+          Aws::InstanceProfileCredentials.new()
+        elsif s3_configuration[:access_key_id] && s3_configuration[:secret_access_key]
+          Aws::Credentials.new(s3_configuration[:access_key_id], s3_configuration[:secret_access_key])
+        end
       end
 
       #

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "ohai",             "~> 8.0"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
-  gem.add_dependency "aws-sdk",          "~> 2"
+  gem.add_dependency "aws-sdk",          "~> 2.11.8"
   gem.add_dependency "thor",             "~> 0.18"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "license_scout"


### PR DESCRIPTION
First, this backports changes from 5.6 that allow better connection to s3 endpoints and allows you to fill the bucket cache prior to running the build.

Second, this allows you to download from s3 buckets that aren't public.

Third, it expands the number of options allowed for credentials, including instance profiles and role authentication.