### PR TITLE
[license_scout] pin to 1.x

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk",          "~> 2"
   gem.add_dependency "thor",             "~> 0.18"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
-  gem.add_dependency "license_scout"
+  gem.add_dependency "license_scout",    "~> 1.0"
+
   gem.add_dependency 'httparty'
   # Pin ffi (dep of ohai) to a version that can be compiled with older autoconfs
   gem.add_dependency "ffi",              "1.9.18"


### PR DESCRIPTION
### Description

Pin license_scout to `1.0.1` like the omnibus fellas do. 

`license_scout ~> 2.02` pulls in rugged which requires `cmake` for building which we do not have available in our builders.
