### PR TITLE
[pedump] dropping dead fork using upstream + gemfile cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-# Fork to allow for a recent version of multipart-post.
-gem "pedump", git: "https://github.com/ksubrama/pedump", branch: "patch-1"
-
-# Always use license_scout from master
-gem "license_scout", github: "chef/license_scout"
-
 group :docs do
   gem "yard",          "~> 0.8"
   gem "redcarpet",     "~> 2.2.2"

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,13 +21,12 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ["lib"]
 
-  # https://github.com/ksubrama/pedump, branch 'patch-1'
-  # is declared in the Gemfile because of its outdated
-  # dependency on multipart-post (~> 1.1.4)
   gem.add_dependency "chef-sugar",       "~> 3.3"
   gem.add_dependency "cleanroom",        "~> 1.0"
   gem.add_dependency "mixlib-shellout",  "~> 2.0"
   gem.add_dependency "mixlib-versioning"
+  gem.add_dependency "pedump"
+
   gem.add_dependency "ohai",             "~> 8.0"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "aws-sdk",          "~> 2"


### PR DESCRIPTION
### Description

`pedump` patched fork is now dead, moving back to upstream gem.

Also some gemfile cleanup.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
