### PR TITLE
Fix version matching to only use agent's tags

### DIFF
--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -157,7 +157,8 @@ module Omnibus
     # @return [String]
     def git_describe
       @git_describe ||= begin
-        cmd = shellout('git describe --tags', cwd: @path)
+        # We only match tags starting with a number to discards non-agent ones (like: dca-1.1.0)
+        cmd = shellout("git describe --tags --match '[0-9]*'", cwd: @path)
 
         if cmd.exitstatus == 0
           cmd.stdout.chomp


### PR DESCRIPTION
### Description

We now tag our repo for multiple project (like agent6 and DCA agent for datadog-agent). Omnibus
is only use to build agent5 and agent6, there tags don't have a prefix and directly start by the major.
