### PR TITLE
[healthcheck] Add Kerberos to the macOS whitelist

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -140,6 +140,7 @@ module Omnibus
       /Cocoa$/,
       /Carbon$/,
       /IOKit$/,
+      /Kerberos/,
       /Tk$/,
       /libutil\.dylib/,
       /libffi\.dylib/,


### PR DESCRIPTION
Needed for the pykerberos python package. Kerberos is part of the base
macOS install (`com.apple.pkg.Essentials` package):

```
> pkgutil --file-info /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
[...]
pkgid: com.apple.pkg.Essentials
[...]
```

Related: https://github.com/DataDog/datadog-agent/pull/3261