### PR TITLE
[NetFetcher] Make downloaded file name unique to the software def

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -117,7 +117,7 @@ module Omnibus
     #
     def downloaded_file
       filename = File.basename(source[:url], "?*")
-      File.join(Config.cache_dir, filename)
+      File.join(Config.cache_dir, "#{self.name}-#{filename}")
     end
 
     #

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -116,8 +116,18 @@ module Omnibus
     # @return [String]
     #
     def downloaded_file
-      filename = File.basename(source[:url], "?*")
-      File.join(Config.cache_dir, "#{self.name}-#{filename}")
+      basename = File.basename(source[:url], "?*")
+      File.join(Config.cache_dir, "#{self.name}-#{basename}")
+    end
+
+    #
+    # The target filename to copy the downloaded file as.
+    # Defaults to {#downloaded_file} unless overriden on the source.
+    #
+    # @return [String]
+    #
+    def target_filename
+      source[:target_filename] || downloaded_file
     end
 
     #
@@ -212,7 +222,7 @@ module Omnibus
           # In the more likely case that we got a "regular" file, we want that
           # file to live **inside** the project directory. project_dir should already
           # exist due to create_required_directories
-          FileUtils.cp(downloaded_file, project_dir)
+          FileUtils.cp(downloaded_file, File.join(project_dir, target_filename))
         end
       end
     end

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -172,6 +172,7 @@ module Omnibus
       if Config.use_s3_caching && Config.s3_authenticated_download
         get_from_s3
       else
+        log.info(log_key) { "Fetching file from `#{download_url}'" }
         download_file!(download_url, downloaded_file, options)
       end
     end
@@ -180,6 +181,7 @@ module Omnibus
     # Download the file directly from s3 using get_object
     #
     def get_from_s3
+      log.info(log_key) { "Fetching file from S3 object `#{S3Cache.key_for(self)}' in bucket `#{Config.s3_bucket}'" }
       begin
         S3Cache.get_object(downloaded_file, self)
       rescue Aws::S3::Errors::NoSuchKey => e
@@ -306,7 +308,7 @@ module Omnibus
     #   if the checksum does not match
     #
     def verify_checksum!
-      log.info(log_key) { "Verifying checksum" }
+      log.info(log_key) { "Verifying checksum of `#{downloaded_file}'" }
 
       expected = checksum
       actual   = digest(downloaded_file, digest_type)

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -222,6 +222,7 @@ module Omnibus
           # In the more likely case that we got a "regular" file, we want that
           # file to live **inside** the project directory. project_dir should already
           # exist due to create_required_directories
+          log.info(log_key) { "`#{safe_downloaded_file}' is a regular file - naming copy `#{target_filename}'" }
           FileUtils.cp(downloaded_file, File.join(project_dir, target_filename))
         end
       end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -285,6 +285,9 @@ module Omnibus
     #   a warning message to print when downloading
     # @option val [Symbol] :extract (nil)
     #   either :tar, :lax_tar :seven_zip
+    # @option val [String] :target_filename (nil)
+    #   when the source is a single (non-extractable) file, the filename it will be accessible as in the project_dir
+    #   defaults to "#{software.name}-#{URLBasename}"
     #
     # Only used in path_fetcher:
     #
@@ -314,7 +317,7 @@ module Omnibus
         extra_keys = val.keys - [
           :git, :path, :url, # fetcher types
           :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
-          :cookie, :warning, :unsafe, :extract, # used by net_fetcher
+          :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
           :options, # used by path_fetcher
           :submodules, :always_fetch_tags # used by git_fetcher
         ]

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -286,8 +286,9 @@ module Omnibus
     # @option val [Symbol] :extract (nil)
     #   either :tar, :lax_tar :seven_zip
     # @option val [String] :target_filename (nil)
-    #   when the source is a single (non-extractable) file, the filename it will be accessible as in the project_dir
-    #   defaults to "#{software.name}-#{URLBasename}"
+    #   when the source is a single (non-extractable) file, the file will be present under this name
+    #   in the project_dir.
+    #   Defaults to "#{software.name}-#{URLBasename}"
     #
     # Only used in path_fetcher:
     #


### PR DESCRIPTION
### What this PR does

On `NetFetcher`/`Software`:
1. Fix the name of the downloaded file so that it's unique to the software def, see f1d43d4e52edea556fb052d1aaeef5b14bd6c44b. This is technically a breaking change for software defs that download a single non-archive file.
1. Allow software definitions that download a single non-archive file to define the name that this file should have in the project dir once downloaded, see 6e259d9
1. Improve logging so that it's clear from where it downloads the file, and what the path on disk of the downloaded file is, see 5d20d183e0463411e3e80193a0bb0c8bf0e5de41

### Motivation

The `pip2` and `pip3`software def of the `datadog-agent` project share the same source URL, which could lead to race conditions since the filename on disk of the downloaded files were identical.

### Related (required) PRs

https://github.com/DataDog/omnibus-software/pull/312
https://github.com/DataDog/datadog-agent/pull/3446

Make `6.11.x` branch of `datadog-agent` use a branch of `omnibus-ruby` that will not include this PR's changes: https://github.com/DataDog/datadog-agent/pull/3449