### PR TITLE
[ship_source] Improve source shipping mechanism by not downloading sources twice

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -837,27 +837,6 @@ module Omnibus
     expose :ship_license
 
     #
-    # Downloads a software source code to ship with the final build
-    #
-    # Sources will be copied into {install_dir}/sources/{software_name}
-    #
-    # @param [String] url
-    #   An URL pointing to a source code archive
-    #
-    def ship_source(url)
-      build_commands << BuildCommand.new("Adding Source code: `#{url}'") do
-        dir_name = "#{install_dir}/sources/#{self.name}"
-        FileUtils.mkdir_p(dir_name)
-        raise "Source #{url} is not starting with http" unless url.start_with? "http"
-        file_name = "#{dir_name}/" + url.split("/")[-1]
-        File.open(file_name, "wb") do |f|
-          log.info(log_key) { "Writing source archive from #{url} to #{file_name}" }
-          f.write HTTParty.get(url).parsed_response
-        end
-      end
-    end
-
-    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/fetcher.rb
+++ b/lib/omnibus/fetcher.rb
@@ -71,6 +71,7 @@ module Omnibus
     #
     attr_reader :project_dir
     attr_reader :build_dir
+    attr_reader :sources_dir
 
     #
     # Create a new Fetcher object from the given software.
@@ -82,14 +83,16 @@ module Omnibus
     # @param [ManifestEntry] manifest_entry
     # @param [String] project_dir
     # @param [String] build_dir
+    # @param [String] sources_dir
     #
-    def initialize(manifest_entry, project_dir, build_dir)
+    def initialize(manifest_entry, project_dir, build_dir, sources_dir)
       @name    = manifest_entry.name
       @source  = manifest_entry.locked_source
       @resolved_version = manifest_entry.locked_version
       @described_version = manifest_entry.described_version
       @project_dir = project_dir
       @build_dir = build_dir
+      @sources_dir = sources_dir
     end
 
     #

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -131,6 +131,15 @@ module Omnibus
     end
 
     #
+    # Tells if the sources should be shipped
+    #
+    # @return [Boolean]
+    #
+    def ship_source?
+      source[:ship_source]
+    end
+
+    #
     # The checksum as defined by the user in the software definition.
     #
     # @return [String]
@@ -224,6 +233,15 @@ module Omnibus
           # exist due to create_required_directories
           log.info(log_key) { "`#{safe_downloaded_file}' is a regular file - naming copy `#{target_filename}'" }
           FileUtils.cp(downloaded_file, File.join(project_dir, target_filename))
+        end
+      end
+      if ship_source?
+        FileUtils.mkdir_p("#{sources_dir}/#{name}")
+        log.info(log_key) { "Moving the sources #{sources_dir}/#{name}/#{downloaded_file.split("/")[-1]}" }
+        if File.directory?(downloaded_file)
+          FileUtils.cp_r("#{downloaded_file}/.", "#{sources_dir}/#{name}")
+        else
+          FileUtils.cp(downloaded_file, "#{sources_dir}/#{name}")
         end
       end
     end


### PR DESCRIPTION
### Description

Previously, when source files needed to be shipped alongside a software, we
downloaded the source to build it, and downloaded it again to add it to the
`sources/` folder of the final package. This was a waste of network resources,
and additionally it could cause a build to fail (for example if the site hosting
the source became offline during the packaging) when we could avoid it by
reusing the already-downloaded package.

The way of shipping the source has been changed: the `Project` tells each `Software`
where to put its sources (if the sources need to be shipped).
The `ship_source true` command must be added to a software definition before
the `source` command to indicate that the sources must also be shipped.
After all `Softwares` have been loaded, the sources are taken from this place and
put into the installation directory, in the `sources/` sub-directory.

Once this PR is merged, software definitions need to be changed in the `omnibus-software` repo ([PR here](https://github.com/DataDog/omnibus-software/pull/318)) and in the `datadog-agent` repo ([PR here](https://github.com/DataDog/datadog-agent/pull/3698)).