### PR TITLE
[macOS] Health check fix for dependencies including @rpath in their location

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -498,10 +498,12 @@ module Omnibus
         rpath_regexp = Regexp.new("@rpath")
         install_dir_regexp = Regexp.new(project.install_dir)
 
+        # Do the linker's work of replacing @rpath with the rpaths defined by the library
         if linked =~ rpath_regexp
           possible_paths = []
           yield_shellout_results("otool -l #{current_library} | grep LC_RPATH -A2 | grep path | awk '{ print $2 }'") do |rpath|
-            possible_paths += linked.sub("@rpath", rpath)
+            # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
+            possible_paths << linked.sub("@rpath", rpath.chop)
           end
         else
           possible_paths = [linked]

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -501,6 +501,19 @@ module Omnibus
         # Do the linker's work of replacing @rpath with the rpaths defined by the library
         if linked =~ rpath_regexp
           possible_paths = []
+          # Find what are the library's rpaths by looking at the load commands.
+          # Example otool -l partial output:
+          # Load command 13
+          #          cmd LC_LOAD_DYLIB
+          #      cmdsize 56
+          #         name /usr/lib/libSystem.B.dylib (offset 24)
+          #   time stamp 2 Thu Jan  1 01:00:02 1970
+          #      current version 1238.60.2
+          # compatibility version 1.0.0
+          # Load command 14
+          #          cmd LC_RPATH
+          #      cmdsize 48
+          #         name /opt/datadog-agent/embedded/lib (offset 12)
           yield_shellout_results("otool -l #{current_library} | grep LC_RPATH -A2 | grep path | awk '{ print $2 }'") do |rpath|
             # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
             possible_paths << linked.sub("@rpath", rpath.chop)


### PR DESCRIPTION
### Description

Modified the health check for macOS by manually expanding the
`@rpath` special path in case it is present.

### Motivation

With the inclusion of libraries which have dependencies containing
`@rpath`, the use of `otool` is not enough anymore. `otool` doesn't
automatically expand `rpaths`, and since the health check expects the
installation directory to be in the dependency's path, it will
fail for these libraries.

### Additional notes

- I'm not sure the `@rpath` expansion is complete, notably in the case of cascading dependencies (`lib1` uses `lib2` which uses `lib3`...)
- The problem remains for `@loader_path`, but getting a fix to work with this is harder because we cannot test it easily (every dependency containing a `@loader_path` in the agent project is white-listed) and the way of expanding it may not be as straightforward (the docs about it aren't clear)