### PR TITLE
 [health_check] Fix health-check on macOS when @loader_path is used

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -496,6 +496,7 @@ module Omnibus
 
       if !safe
         rpath_regexp = Regexp.new("@rpath")
+        loader_path_regexp = Regexp.new("@loader_path")
         install_dir_regexp = Regexp.new(project.install_dir)
 
         # Do the linker's work of replacing @rpath with the rpaths defined by the library
@@ -518,6 +519,9 @@ module Omnibus
             # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
             possible_paths << linked.sub("@rpath", rpath.chop)
           end
+        elsif linked =~ loader_path_regexp
+          loader_path = File.dirname(current_library)
+          possible_paths = [linked.sub("@loader_path", loader_path)]
         else
           possible_paths = [linked]
         end

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -489,9 +489,10 @@ module Omnibus
         safe ||= true if reg.match(current_library)
       end
 
-      log.debug(log_key) { "  --> Dependency: #{name}" }
-      log.debug(log_key) { "  --> Provided by: #{linked}" }
-
+      log.info(log_key) { "  --> Dependency: #{name}" }
+      log.info(log_key) { "  --> Library: #{current_library}" }
+      log.info(log_key) { "  --> Provided by: #{linked}" }
+      log.info(log_key) { "  --> Whitelisted: #{safe}" }
       linked_present = false
 
       if !safe

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -482,19 +482,16 @@ module Omnibus
       whitelist_libs = MAC_WHITELIST_LIBS
 
       whitelist_libs.each do |reg|
-        log.info(log_key) { "  --> Whitelist lib: #{reg}" }
         safe ||= true if reg.match(name)
       end
 
       whitelist_files.each do |reg|
-        log.info(log_key) { "  --> Whitelist file: #{reg}" }
         safe ||= true if reg.match(current_library)
       end
 
-      log.info(log_key) { "  --> Dependency: #{name}" }
-      log.info(log_key) { "  --> Library: #{current_library}" }
-      log.info(log_key) { "  --> Provided by: #{linked}" }
-      log.info(log_key) { "  --> Whitelisted: #{safe}" }
+      log.debug(log_key) { "  --> Dependency: #{name}" }
+      log.debug(log_key) { "  --> Provided by: #{linked}" }
+
       linked_present = false
 
       if !safe
@@ -522,6 +519,7 @@ module Omnibus
             # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
             possible_paths << linked.sub("@rpath", rpath.chop)
           end
+        # Do the linker's work of replacing @loader_path by the directory the library that's using the dependency is in
         elsif linked =~ loader_path_regexp
           loader_path = File.dirname(current_library)
           possible_paths = [linked.sub("@loader_path", loader_path)]

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -482,10 +482,12 @@ module Omnibus
       whitelist_libs = MAC_WHITELIST_LIBS
 
       whitelist_libs.each do |reg|
+        log.info(log_key) { "  --> Whitelist lib: #{reg}" }
         safe ||= true if reg.match(name)
       end
 
       whitelist_files.each do |reg|
+        log.info(log_key) { "  --> Whitelist file: #{reg}" }
         safe ||= true if reg.match(current_library)
       end
 


### PR DESCRIPTION
### Description

Manually expands `@loader_path` when encountered during the health check phase.

### Motivation

Some of our libraries have dependencies located with `@loader_path` (in particular some python libraries in `site-packages`). They were whitelisted in the health-check because `otool` doesn't expand the `@loader_path` special variable, resulting in an error when checking if the dependencies are present.