### PR TITLE
Add ability to sign with pfx file & password in addition to stored

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -27,7 +27,7 @@ module Omnibus
         helper_tmp_dir = Dir.mktmpdir
         parameters.store('HelperDir', helper_tmp_dir)
         FileUtils.mv "#{install_dir}/bin/upgrade-helper.exe", "#{helper_tmp_dir}"
-        if signing_identity
+        if signing_identity or signing_identity_file
           Dir["#{helper_tmp_dir}" + "/**/*.{exe,dll}"].each do |signfile|
             sign_package(signfile)
           end
@@ -68,7 +68,7 @@ module Omnibus
     end
 
     build do
-      if signing_identity
+      if signing_identity or signing_identity_file
         puts "starting signing"
         if additional_sign_files
             additional_sign_files.each do |signfile|
@@ -128,7 +128,7 @@ module Omnibus
         msi_file = windows_safe_path(Config.package_dir, msi_name)
         shellout!(light_command(msi_file, wixobj_list: wixobj_list), returns: [0, 204])
 
-        if signing_identity
+        if signing_identity or signing_identity_file
           sign_package(msi_file)
         end
 
@@ -141,7 +141,7 @@ module Omnibus
           bundle_file = windows_safe_path(Config.package_dir, bundle_name)
           shellout!(light_command(bundle_file, is_bundle: true), returns: [0, 204])
 
-          if signing_identity
+          if signing_identity or signing_identity_file
             sign_package(bundle_file, is_bundle: true)
           end
         end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -47,6 +47,9 @@ module Omnibus
     #
     def signing_identity(thumbprint = NULL, params = NULL)
       unless null?(thumbprint)
+        if signing_identity_file
+          raise Error, "You cannot specify signing_identity and signing_identity_file"
+        end
         @signing_identity = {}
         unless thumbprint.is_a?(String)
           raise InvalidValue.new(:signing_identity, "be a String")
@@ -90,21 +93,87 @@ module Omnibus
       signing_identity[:thumbprint]
     end
 
-    def algorithm
-      signing_identity[:algorithm]
-    end
-
     def cert_store_name
       signing_identity[:store]
-    end
-
-    def timestamp_servers
-      signing_identity[:timestamp_servers]
     end
 
     def machine_store?
       signing_identity[:machine_store]
     end
+
+    def signing_identity_file(pfxfile = NULL, params = NULL)
+      unless null?(pfxfile)
+        if signing_identity
+          raise Error, "You cannot specify signing_identity and signing_identity_file"
+        end
+        @signing_identity_file = {}
+        unless pfxfile.is_a?(String)
+          raise InvalidValue.new(:pfxfile, "be a String")
+        end
+
+        @signing_identity_file[:pfxfile] = pfxfile
+
+        if !null?(params)
+          unless params.is_a?(Hash)
+            raise InvalidValue.new(:params, "be a Hash")
+          end
+
+          valid_keys = [:password, :timestamp_servers, :algorithm]
+          invalid_keys = params.keys - valid_keys
+          unless invalid_keys.empty?
+            raise InvalidValue.new(:params, "contain keys from [#{valid_keys.join(', ')}]. "\
+                                   "Found invalid keys [#{invalid_keys.join(', ')}]")
+          end
+
+          if params[:password].nil? 
+            raise InvalidValue.new(:params, "Must supply password for PFX file")
+          end
+        else
+          params = {}
+        end
+
+        @signing_identity_file[:algorithm] = params[:algorithm] || "SHA1"
+        servers = params[:timestamp_servers] || DEFAULT_TIMESTAMP_SERVERS
+        @signing_identity_file[:timestamp_servers] = [servers].flatten
+        @signing_identity_file[:password] = params[:password] || false
+        end
+
+        @signing_identity_file
+    end
+    expose :signing_identity_file
+
+    def pfx_algorithm
+      signing_identity_file[:algorithm]
+    end
+
+    def pfx_password
+      signing_identity_file[:password]
+    end
+
+    def pfx_file
+      signing_identity_file[:pfxfile]
+    end
+
+    def timestamp_servers
+      if signing_identity
+        signing_identity[:timestamp_servers]
+      elsif signing_identity_file
+        signing_identity_file[:timestamp_servers]
+      else
+        nil
+      end
+    end
+
+    def algorithm
+      if signing_identity
+        signing_identity[:algorithm]
+      elsif signing_identity_file
+        signing_identity_file[:algorithm]
+      else
+        nil
+      end
+    end
+  
 
     #
     # Iterates through available timestamp servers and tries to sign
@@ -141,17 +210,30 @@ module Omnibus
     end
 
     def try_sign(package_file, url)
-      cmd = Array.new.tap do |arr|
-        arr << "signtool.exe"
-        arr << "sign /v"
-        arr << "/t #{url}"
-        arr << "/fd #{algorithm}"
-        arr << "/sm" if machine_store?
-        arr << "/s #{cert_store_name}"
-        arr << "/sha1 #{thumbprint}"
-        arr << "/d #{project.package_name}"
-        arr << "\"#{package_file}\""
-      end.join(" ")
+      if signing_identity
+        cmd = Array.new.tap do |arr|
+          arr << "signtool.exe"
+          arr << "sign /v"
+          arr << "/t #{url}"
+          arr << "/fd #{algorithm}"
+          arr << "/sm" if machine_store?
+          arr << "/s #{cert_store_name}"
+          arr << "/sha1 #{thumbprint}"
+          arr << "/d #{project.package_name}"
+          arr << "\"#{package_file}\""
+        end.join(" ")
+      elsif signing_identity_file
+        cmd = Array.new.tap do |arr|
+          arr << "signtool.exe"
+          arr << "sign /v"
+          arr << "/t #{url}"
+          arr << "/f #{pfx_file}"
+          arr << "/fd #{algorithm}"
+          arr << "/p #{pfx_password}"
+          arr << "/d #{project.package_name}"
+          arr << "\"#{package_file}\""
+        end.join(" ")
+      end
       puts cmd
       status = shellout(cmd)
       if status.exitstatus != 0


### PR DESCRIPTION
Merges change from `datadog-5.5.0` to allow signing with temporary file & password pulled from SSM.  Allows for more secure signing of packages, and allows us to rotate the certs w/o changing code or build boxes (when these expire)


--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
