### PR TITLE
Change default value of strip_build to allow turning off

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -844,7 +844,7 @@ module Omnibus
     #
     # @return [String]
     #
-    def strip_build(val = true)
+    def strip_build(val = NULL)
       if null?(val)
         @strip_build || false
       else


### PR DESCRIPTION
### Description

Freshly merged feature of stripping debug packages cannot be disabled at project level, since it's always returned as `true`

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
