### PR TITLE
[stripper] add support for strip exclusion

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -653,6 +653,27 @@ module Omnibus
     expose :debug_path
 
     #
+    # Add a strip exclude path.
+    #
+    # Paths added here will be excluded from the stripping process.
+    #
+    # @example
+    #   strip_exclude 'foo/bar'
+    #   dependency 'quz'
+    #
+    # @param [String] val
+    #   the path to exclude from stripping
+    #
+    # @return [Array<String>]
+    #   the list of dependencies
+    #
+    def strip_exclude(pattern)
+      strip_exclude_paths << pattern
+      strip_exclude_paths.dup
+    end
+    expose :strip_exclude
+
+    #
     # Add a package that is a runtime dependency of this project.
     #
     # This is distinct from a build-time dependency, which should correspond to
@@ -961,6 +982,19 @@ module Omnibus
     #
     def debug_package_paths
       @debug_package_paths ||= []
+    end
+
+    # The list of paths to exclude in the stripping process.
+    # Paths here specified will be excluded when stripping.
+    #
+    # @see #strip_exclude
+    #
+    # @param [Array<String>]
+    #
+    # @return [Array<String>]
+    #
+    def strip_exclude_paths
+      @strip_exclude_paths ||= []
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -265,6 +265,27 @@ module Omnibus
     expose :debug_path
 
     #
+    # Add a strip exclude path.
+    #
+    # Paths added here will be excluded from the stripping process.
+    #
+    # @example
+    #   strip_exclude 'foo/bar'
+    #   dependency 'quz'
+    #
+    # @param [String] val
+    #   the path to exclude from stripping
+    #
+    # @return [Array<String>]
+    #   the list of dependencies
+    #
+    def strip_exclude(pattern)
+      strip_exclude_paths << pattern
+      strip_exclude_paths.dup
+    end
+    expose :strip_exclude
+
+    #
     # Set or retrieve the source for the software.
     #
     # @raise [InvalidValue]
@@ -999,6 +1020,19 @@ module Omnibus
     #
     def debug_package_paths
       @debug_package_paths ||= []
+    end
+
+    # The list of paths to exclude in the stripping process.
+    # Paths here specified will be excluded when stripping.
+    #
+    # @see #strip_exclude
+    #
+    # @param [Array<String>]
+    #
+    # @return [Array<String>]
+    #
+    def strip_exclude_paths
+      @strip_exclude_paths ||= []
     end
 
     #


### PR DESCRIPTION
### Description

There's a known bug with manylinux wheels, `patchelf` and `binutils` that may break binaries after stripping if `patchelf` was used previously on the stripped binary. See: https://github.com/pypa/manylinux/issues/119

We might therefore need to skip stripping on some paths/patterns. This PR adds support for that.