### PR TITLE
[Health check] Whitelist libdb-5.3.so

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -33,6 +33,7 @@ module Omnibus
       /libc\.so/,
       /libcrypt\.so/,
       /libdb-4.7\.so/,
+      /libdb-5.3\.so/,
       /libdl/,
       /libfreebl\d\.so/,
       /libgcc_s\.so/,


### PR DESCRIPTION
### Description

Needed for the ARM build, as `_bsddb.so` requires `/usr/lib64/libdb-5.3.so`. We already whitelisted `libdb-4.7.so` for the Intel build, and it's not actually used by the Agent, so it should be safe to whitelist it.
