### PR TITLE
Pin ffi-yajl to 2.3.1

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -34,12 +34,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor",             "~> 0.18"
   # TODO: Check if future versions of ffi-yajl fix the x86 Windows build.
   # Version 2.3.3 of the gem breaks it
-  gem.add_dependency "ffi-yajl",         "2.3.1"
+  gem.add_dependency "ffi-yajl",         "= 2.3.1"
   gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency 'httparty'
   # Pin ffi (dep of ohai) to a version that can be compiled with older autoconfs
-  gem.add_dependency "ffi",              "1.9.18"
+  gem.add_dependency "ffi",              "= 1.9.18"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,7 +32,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "aws-sdk",          "~> 2.11.8"
   gem.add_dependency "thor",             "~> 0.18"
-  gem.add_dependency "ffi-yajl",         "~> 2.2"
+  # TODO: Check if future versions of ffi-yajl fix the x86 Windows build.
+  # Version 2.3.3 of the gem breaks it
+  gem.add_dependency "ffi-yajl",         "2.3.1"
   gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency 'httparty'


### PR DESCRIPTION
### Description

Pin `ffi-yajl` to 2.3.1: update 2.3.3 breaks the Windows x86 build.