### PR TITLE
Update ffi-yajl gem dependency

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,9 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "aws-sdk",          "~> 2.11.8"
   gem.add_dependency "thor",             "~> 0.18"
-  # TODO: Check if future versions of ffi-yajl fix the x86 Windows build.
-  # Version 2.3.3 of the gem breaks it
-  gem.add_dependency "ffi-yajl",         "= 2.3.1"
+  gem.add_dependency "ffi-yajl",         "~> 2.3"
   gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency 'httparty'


### PR DESCRIPTION
### Description

Go back to the previous version constraint now that the Windows builders have been fixed.