### PR TITLE
[project, software] Add code-signing identity parameter

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -915,6 +915,28 @@ module Omnibus
     expose :text_manifest_path
 
     #
+    # Set or return the code signing identity. Can be used in software definitions
+    # to sign components of the package.
+    #
+    # @example
+    #   code_signing_identity "foo"
+    #
+    # @param [String] val
+    #   the identity to use when code signing
+    #
+    # @return [String]
+    #   the code-signing identity
+    #
+    def code_signing_identity(val = NULL)
+      if null?(val)
+        @code_signing_identity
+      else
+        @code_signing_identity = val
+      end
+    end
+    expose :code_signing_identity
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -936,6 +936,19 @@ module Omnibus
     expose :ship_source
 
     #
+    # Return the code signing identity. Can be used in software definitions
+    # to sign components of the package.
+    # Inherited from the parent project.
+    #
+    # @return [String]
+    #   the code-signing identity
+    #
+    def code_signing_identity
+      @project.code_signing_identity
+    end
+    expose :code_signing_identity
+
+    #
     # @!endgroup
     # --------------------------------------------------
 


### PR DESCRIPTION
### Description

Support defining a project-level code signing identity that can be used by software definitions which need to sign their components.
