### PR TITLE
[windows_base] Add timestamp server and print which timestamp server is used

### DIFF
--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -201,6 +201,7 @@ module Omnibus
       end
 
       timestamp_servers.each do |ts|
+        puts "signing with timestamp server: #{ts}"
         success = try_sign(safe_package_file, ts)
 
         puts "signed" if success

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -204,7 +204,7 @@ module Omnibus
         puts "signing with timestamp server: #{ts}"
         success = try_sign(safe_package_file, ts)
 
-        puts "signed" if success
+        puts "signed with timestamp server: #{ts}" if success
 
         break if success
       end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -17,7 +17,8 @@
 module Omnibus
   class Packager::WindowsBase < Packager::Base
     DEFAULT_TIMESTAMP_SERVERS = ["http://timestamp.digicert.com",
-                                 "http://timestamp.verisign.com/scripts/timestamp.dll"]
+                                 "http://timestamp.verisign.com/scripts/timestamp.dll",
+                                 "http://timestamp.globalsign.com/scripts/timstamp.dll"]
 
     #
     # Set the signing certificate name


### PR DESCRIPTION
### What does this PR do?

Adds a log message describing which timestamp server is being used for signing.
Adds new timestamp server in case the first two fail.

### Motivation

More visibility on what's happening during a package build.

