### PR TITLE
[project, software] Add entitlements file DSL

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -915,6 +915,7 @@ module Omnibus
     expose :text_manifest_path
 
     #
+    # [MacOS only]
     # Set or return the code signing identity. Can be used in software definitions
     # to sign components of the package.
     #
@@ -935,6 +936,29 @@ module Omnibus
       end
     end
     expose :code_signing_identity
+
+    #
+    # [MacOS only]
+    # Set or return the location of the Entitlements file. Can be used
+    # in software definitions to specify entitlements when signing files.
+    #
+    # @example
+    #   entitlements_file "foo"
+    #
+    # @param [String] val
+    #   the location of the Entitlements file
+    #
+    # @return [String]
+    #   the location of the Entitlements file
+    #
+    def entitlements_file(val = NULL)
+      if null?(val)
+        @entitlements_file
+      else
+        @entitlements_file = val
+      end
+    end
+    expose :entitlements_file
 
     #
     # @!endgroup

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -936,6 +936,7 @@ module Omnibus
     expose :ship_source
 
     #
+    # [MacOS only]
     # Return the code signing identity. Can be used in software definitions
     # to sign components of the package.
     # Inherited from the parent project.
@@ -947,6 +948,20 @@ module Omnibus
       @project.code_signing_identity
     end
     expose :code_signing_identity
+
+    #
+    # [MacOS only]
+    # Return the location of the Entitlements file. Can be used
+    # in software definitions to specify entitlements when signing files.
+    # Inherited from the parent project.
+    #
+    # @return [String]
+    #   the Entitlements file location
+    #
+    def entitlements_file
+      @project.entitlements_file
+    end
+    expose :entitlements_file
 
     #
     # @!endgroup


### PR DESCRIPTION
### Description

Support defining a project-level code entitlements file that can be used by software definitions which need to sign their components.