### PR TITLE
Fail if copying/moving/symlinking zero files

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -598,7 +598,7 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          raise "no matched files for glob #{command}" if files.empty?
+          raise "no matched files for glob #{command}" if files.empty? && !options[:force]
 
           files.each do |file|
             FileUtils.cp_r(file, destination, options)
@@ -625,7 +625,7 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          raise "no matched files for glob #{command}" if files.empty?
+          raise "no matched files for glob #{command}" if files.empty? && !options[:force]
 
           files.each do |file|
             FileUtils.mv(file, destination, options)
@@ -652,7 +652,7 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          raise "no matched files for glob #{command}" if files.empty?
+          raise "no matched files for glob #{command}" if files.empty? && !options[:force]
 
           files.each do |file|
             FileUtils.ln_s(file, destination, options)

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -598,12 +598,10 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          if files.empty?
-            log.warn(log_key) { "no matched files for glob #{command}" }
-          else
-            files.each do |file|
-              FileUtils.cp_r(file, destination, options)
-            end
+          raise "no matched files for glob #{command}" if files.empty?
+
+          files.each do |file|
+            FileUtils.cp_r(file, destination, options)
           end
         end
       end
@@ -627,12 +625,10 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          if files.empty?
-            log.warn(log_key) { "no matched files for glob #{command}" }
-          else
-            files.each do |file|
-              FileUtils.mv(file, destination, options)
-            end
+          raise "no matched files for glob #{command}" if files.empty?
+
+          files.each do |file|
+            FileUtils.mv(file, destination, options)
           end
         end
       end
@@ -656,12 +652,10 @@ module Omnibus
       build_commands << BuildCommand.new(command) do
         Dir.chdir(software.project_dir) do
           files = FileSyncer.glob(source)
-          if files.empty?
-            log.warn(log_key) { "no matched files for glob #{command}" }
-          else
-            files.each do |file|
-              FileUtils.ln_s(file, destination, options)
-            end
+          raise "no matched files for glob #{command}" if files.empty?
+
+          files.each do |file|
+            FileUtils.ln_s(file, destination, options)
           end
         end
       end


### PR DESCRIPTION
### Description

- Fail when copying, moving or symlinking if the glob pattern matches zero files to ensure catching errors early.
- Tested on datadog-agent pipeline 2849769
- Not sure if I am merging into the right branch