### PR TITLE
[RPM] Decouple GPG key name from maintainer

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -132,7 +132,7 @@ module Omnibus
 
     #
     # Set or return the signing passphrase.
-    # Required if gpg_key_name is set.
+    # If this value is provided, Omnibus will attempt to sign the RPM.
     #
     # @example
     #   signing_passphrase "foo"

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -114,7 +114,7 @@ module Omnibus
     # If this value is provided, Omnibus will attempt to sign the RPM.
     #
     # @example
-    #   gpg_key_name 'My key (my.address@here.com)'
+    #   gpg_key_name 'My key <my.address@here.com>'
     #
     # @param [String] val
     #   the name of the GPG key to use during RPM signing

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -117,9 +117,10 @@ module Omnibus
     #   gpg_key_name 'My key (my.address@here.com)'
     #
     # @param [String] val
-    #   the name of the gpg key
+    #   the name of the GPG key to use during RPM signing
     #
     # @return [String]
+    #   the RPM signing GPG key name
     #
     def gpg_key_name(val = NULL)
       if null?(val)


### PR DESCRIPTION
### What does this PR do?

Creates a new RPM `Packager` field, `gpg_key_name`, to specify a GPG key name that's different from the maintainer name.
If not specified, `project.maintainer` is still used.