### PR TITLE
Show errors in rubocop CI check

### DIFF
--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 echo -e "[RUBOCOP] --> Init (wait a second)"
 
-if (bundle exec rubocop -x 2>/dev/null | grep 'no offenses detected' >/dev/null) ; then
+# For now, only check Layout cops
+# TODO: add other cops (and fix related issues), eg. Lint
+if (bundle exec rubocop --only 'Layout' 2>/dev/null | grep 'no offenses detected' >/dev/null) ; then
     echo -e "[RUBOCOP] --> 👍 approved."
     exit 0
 else
-    echo -e "[RUBOCOP] --> ✋ You've got some offenses - run "'`bundle exec rubocop -x`'
+    bundle exec rubocop --only 'Layout'
+    echo -e "[RUBOCOP] --> ✋ You've got some offenses."
+    echo -e "Run \"bundle exec rubocop --only 'Layout' -a\" to fix them."
     exit 1
 fi


### PR DESCRIPTION
### What does this PR do?

Makes CI errors clearer by showing them to the user in the CI job.
