### PR TITLE
[Project] Add utils and CLI commands to show and save dependency graph of a project

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1383,29 +1383,30 @@ module Omnibus
             }
             output += "    Source (path): #{software.source[:path]}\n"
           elsif software.source.key?(:url)
-            # The source is a remote URL. A hashsum can also be specified,
-            # it will be verified when the source is downloaded.
+            # The source is a remote URL.
             software_hash[:source] = {
               url: software.source[:url]
             }
             output += "    Source (url): #{software.source[:url]}\n"
+          end
 
-            if software.source.key?(:sha512)
-              software_hash[:source][:sha512] = software.source[:sha512]
-              output += "    Hash (sha512): #{software.source[:sha512]}\n"
-            end
-            if software.source.key?(:sha256)
-              software_hash[:source][:sha256] = software.source[:sha256]
-              output += "    Hash (sha256): #{software.source[:sha256]}\n"
-            end
-            if software.source.key?(:sha1)
-              software_hash[:source][:sha1] = software.source[:sha1]
-              output += "    Hash (sha1): #{software.source[:sha1]}\n"
-            end
-            if software.source.key?(:md5)
-              software_hash[:source][:md5] = software.source[:md5]
-              output += "    Hash (md5): #{software.source[:md5]}\n"
-            end
+          # A hashsum can also be specified.
+          # It will be verified when the source is downloaded.
+          if software.source.key?(:sha512)
+            software_hash[:source][:sha512] = software.source[:sha512]
+            output += "    Hash (sha512): #{software.source[:sha512]}\n"
+          end
+          if software.source.key?(:sha256)
+            software_hash[:source][:sha256] = software.source[:sha256]
+            output += "    Hash (sha256): #{software.source[:sha256]}\n"
+          end
+          if software.source.key?(:sha1)
+            software_hash[:source][:sha1] = software.source[:sha1]
+            output += "    Hash (sha1): #{software.source[:sha1]}\n"
+          end
+          if software.source.key?(:md5)
+            software_hash[:source][:md5] = software.source[:md5]
+            output += "    Hash (md5): #{software.source[:md5]}\n"
           end
         end
         # List all dependencies of the software
@@ -1425,6 +1426,24 @@ module Omnibus
         log.info(log_key) { output }
       end
 
+      # Structure of the hash:
+      # {
+      #   "project": {
+      #     "name": "...",
+      #     "version": "..."
+      #   },
+      #   "software": [
+      #     {
+      #       "name": "...",
+      #       "version": "...",
+      #       "source": {
+      #         "url": "...",
+      #         "sha256": "..."
+      #       }
+      #     },
+      #     ...
+      #   ]
+      # }
       deps_graph
     end
 


### PR DESCRIPTION
### Description

Adds a `deps_graph` function which builds a `Hash` and a text representation of the dependencies of a project. These representations can be used to print the dependency graph of a project, and/or save it to a `json` file.

Updates the `build` command to allow showing & saving the dependency graph.
Adds a dedicated `graph` command to compute, show and/or save the dependency graph.

### Motivation

Being able to easily see / parse the dependencies of a project.

### Additional notes

Not 100% sure what's the best format to store the software list:
```
{
  ...
  "software": [
    {
      "name": "libtool",
      "version": "2.4",
      ...
    },
    {
      "name": "libffi",
      "version": "3.2.1",
      ...
    },
    ...
  ]
}
```
which is the current implementation, or:
```
{
  ...
  "software": {
    "libtool": {
      "version": "2.4",
      ...
    },
    "libffi": {
      "version": "3.2.1",
      ...
    },
    ...
  }
}
```

Also note that the dependencies of a dependency is only a list of string identifiers, because that’s how omnibus stores its dependency graph. We could make a second pass to actually resolve the dependency chain, but I’m not sure how useful that really is, since all the needed data is already present in the JSON file.