### PR TITLE
Make it possible to build FIPS-installable RPMs

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -31,6 +31,7 @@ module Omnibus
       /ld-linux/,
       /libc\.so/,
       /libcrypt\.so/,
+      /libdb-4.5\.so/,
       /libdb-4.7\.so/,
       /libdb-5.3\.so/,
       /libdl/,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -516,7 +516,7 @@ module Omnibus
 
             log.info(log_key) { "Creating .rpm file" }
             shellout!("#{command}", environment: { "HOME" => home })
-            shellout!("rpm --addsign #{stage}/RPMS/**/*.rpm")
+            shellout!("rpm --addsign #{stage}/RPMS/**/*.rpm", environment: { "HOME" => home })
           end
         else
           if not has_rpmmacros

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -623,7 +623,7 @@ module Omnibus
     def with_rpm_passphrase(&block)
       directory = Dir.mktmpdir
       passphrase_file = "#{directory}/passphrase"
-      File.open(passphrase_file, 'w', 0700) do |file|
+      File.open(passphrase_file, 'w', 0600) do |file|
         file.write(signing_passphrase)
       end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -98,7 +98,7 @@ module Omnibus
         raise Error.new("Only works with RPM 4")
       end
 
-      fips = rv[:minor].to_i < 14 ? true : false
+      fips = rv[:minor].to_i >= 14 ? true : false
 
       # Generate the spec
       write_rpm_spec(fips)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -98,7 +98,7 @@ module Omnibus
         raise Error.new("Only works with RPM 4")
       end
 
-      fips = rv[:minor] < 14 ? true : false
+      fips = rv[:minor].to_i < 14 ? true : false
 
       # Generate the spec
       write_rpm_spec(fips)

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -482,7 +482,6 @@ module Omnibus
         key_name = gpg_key_name || project.maintainer
         log.info(log_key) { "Using gpg key #{key_name}" }
 
-        command << " --sign"
         command << " #{spec_file(debug)}"
 
         has_rpmmacros = File.exist?("#{ENV['HOME']}/.rpmmacros")
@@ -517,6 +516,7 @@ module Omnibus
 
             log.info(log_key) { "Creating .rpm file" }
             shellout!("#{command}", environment: { "HOME" => home })
+            shellout!("rpm --addsign #{stage}/RPMS/**/*.rpm")
           end
         else
           if not has_rpmmacros

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -90,18 +90,27 @@ module Omnibus
     end
 
     build do
+      # NOTE: for now we assume having RPM >= 4.14 equals building
+      # a FIPS-installable RPM - this might not always be the case,
+      # so we might need to change this in the future.
+      rv = rpm_version
+      if rv[:major] != "4"
+        raise Error.new("Only works with RPM 4")
+      end
+      fips = rv[:minor] < 14 ? true : false
+
       # Generate the spec
-      write_rpm_spec
+      write_rpm_spec(fips)
 
       # Generate the rpm
-      create_rpm_file
+      create_rpm_file(fips)
 
       if debug_build?
         # Generate the spec
-        write_rpm_spec(true)
+        write_rpm_spec(fips, true)
 
         # Generate the rpm
-        create_rpm_file(true)
+        create_rpm_file(fips, true)
       end
     end
 
@@ -371,12 +380,26 @@ module Omnibus
     end
 
     #
+    # Return version of local `rpm`
+    #
+    # @return [MatchData]
+    #
+    def rpm_version
+      version_call = shellout!("rpm --version")
+      match = version_call.stdout.match(/RPM version (?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d.*)/)
+      if match.nil?
+        raise Error.new("Couldn't parse '#{version_call.stdout}' as RPM version")
+      end
+      return match
+    end
+
+    #
     # Render an rpm spec file in +SPECS/#{name}.spec+ using the supplied ERB
     # template.
     #
     # @return [void]
     #
-    def write_rpm_spec(debug = false)
+    def write_rpm_spec(fips, debug = false)
       # Create a map of scripts that exist and their contents
       scripts = SCRIPT_MAP.inject({}) do |hash, (source, destination)|
         script_src = source.to_s
@@ -429,6 +452,7 @@ module Omnibus
                         files: files,
                         build_dir: build_dir(debug),
                         platform_family: Ohai["platform_family"],
+                        fips: fips,
                       })
     end
 
@@ -439,7 +463,7 @@ module Omnibus
     #
     # @return [void]
     #
-    def create_rpm_file(debug = false)
+    def create_rpm_file(fips, debug = false)
       stage = staging_dir
       if debug
         stage = staging_dbg_dir
@@ -459,34 +483,54 @@ module Omnibus
         command << " --sign"
         command << " #{spec_file(debug)}"
 
-        with_rpm_signing do |passphrase_file|
-          if File.exist?("#{ENV['HOME']}/.rpmmacros")
-            log.info(log_key) { "Detected .rpmmacros file at `#{ENV['HOME']}'" }
-            home = ENV["HOME"]
-          else
-            log.info(log_key) { "Using default .rpmmacros file from Omnibus" }
+        has_rpmmacros = File.exist?("#{ENV['HOME']}/.rpmmacros")
+        if has_rpmmacros
+          log.info(log_key) { "Detected .rpmmacros file at `#{ENV['HOME']}'" }
+          home = ENV["HOME"]
+        else
+          log.info(log_key) { "Using default .rpmmacros file from Omnibus" }
+          # Generate a temporary home directory
+          home = Dir.mktmpdir
+        end
 
-            # Generate a temporary home directory
-            home = Dir.mktmpdir
+        if fips
+          with_rpm_passphrase do |passphrase_file|
+            if not has_rpmmacros
+              gpg_extra_args = ""
+              rpm_gpg = shellout!("rpm --eval '%__gpg'")
+              if shellout("#{rpm_gpg.stdout} --pinentry-mode loopback </dev/null 2>&1 | grep -q pinentry-mode").exitstatus == 1
+                gpg_extra_args << " --pinentry-mode loopback"
+              end
 
-            gpg_extra_args = ""
-            rpm_gpg = shellout!("rpm --eval '%__gpg'")
-            if shellout("#{rpm_gpg.stdout} --pinentry-mode loopback </dev/null 2>&1 | grep -q pinentry-mode").exitstatus == 1
-              gpg_extra_args << " --pinentry-mode loopback"
+              render_template(resource_path("rpmmacros.erb"),
+                              destination: "#{home}/.rpmmacros",
+                              variables: {
+                                gpg_name: key_name,
+                                gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
+                                gpg_passphrase_file: passphrase_file,
+                                gpg_extra_args: gpg_extra_args,
+                                fips: true,
+                              })
             end
 
+            log.info(log_key) { "Creating .rpm file" }
+            shellout!("#{command}", environment: { "HOME" => home })
+          end
+        else
+          if not has_rpmmacros
             render_template(resource_path("rpmmacros.erb"),
                             destination: "#{home}/.rpmmacros",
                             variables: {
                               gpg_name: key_name,
                               gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
-                              gpg_passphrase_file: passphrase_file,
-                              gpg_extra_args: gpg_extra_args,
+                              fips: false,
                             })
           end
 
-          log.info(log_key) { "Creating .rpm file" }
-          shellout!("#{command}", environment: { "HOME" => home })
+          with_rpm_signing do |signing_script|
+            log.info(log_key) { "Creating .rpm file" }
+            shellout!("#{signing_script} \"#{command}\"", environment: { "HOME" => home })
+          end
         end
       else
         log.info(log_key) { "Creating .rpm file" }
@@ -543,6 +587,34 @@ module Omnibus
     # @return [String]
     #
     def with_rpm_signing(&block)
+      directory   = Dir.mktmpdir
+      destination = "#{directory}/sign-rpm"
+
+      render_template(resource_path("signing.erb"),
+                      destination: destination,
+                      mode: 0700,
+                      variables: {
+                        passphrase: signing_passphrase,
+                      })
+
+      # Yield the destination to the block
+      yield(destination)
+    ensure
+      remove_file(destination)
+      remove_directory(directory)
+    end
+
+    #
+    # Render a file with gpg key passphrase with secure permissions, call the given
+    # block with the path to the file, and ensure deletion of the file from
+    # disk since it contains sensitive information.
+    #
+    # @param [Proc] block
+    #   the block to call
+    #
+    # @return [String]
+    #
+    def with_rpm_passphrase(&block)
       directory = Dir.mktmpdir
       passphrase_file = "#{directory}/passphrase"
       File.open(passphrase_file, 'w', 0700) do |file|

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -515,10 +515,14 @@ module Omnibus
             end
 
             log.info(log_key) { "Creating .rpm file" }
+            # We don't use `rpmbuild --sign` on newer RPM, as it is deprecated and also
+            # seems to fail for packages with a lot files, like datadog-agent, with CentOS 6
+            # version of `popt`
             shellout!("#{command}", environment: { "HOME" => home })
             shellout!("rpm --addsign #{stage}/RPMS/**/*.rpm", environment: { "HOME" => home })
           end
         else
+          command << " --sign"
           if not has_rpmmacros
             render_template(resource_path("rpmmacros.erb"),
                             destination: "#{home}/.rpmmacros",

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -97,6 +97,7 @@ module Omnibus
       if rv[:major] != "4"
         raise Error.new("Only works with RPM 4")
       end
+
       fips = rv[:minor] < 14 ? true : false
 
       # Generate the spec
@@ -390,6 +391,7 @@ module Omnibus
       if match.nil?
         raise Error.new("Couldn't parse '#{version_call.stdout}' as RPM version")
       end
+
       return match
     end
 

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -1,3 +1,15 @@
 %_signature gpg
 %_gpg_path <%= gpg_path %>
 %_gpg_name <%= gpg_name %>
+
+# Necessary since RPM 4.11 (CentoOS 7), otherwise the GPG signing
+# machinery in RPM will ask for password via pinentry.
+%__gpg_sign_cmd %{__gpg} \
+    gpg --force-v3-sigs --yes --no-tty --no-verbose --no-armor --batch \
+    --passphrase-file <%= gpg_passphrase_file %> --digest-algo sha256 \
+    --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} \
+    %{__plaintext_filename} <%= gpg_extra_args %>
+
+# These are SHA256 - we use them to build packages installable in FIPS mode
+%_source_filedigest_algorithm 8
+%_binary_filedigest_algorithm 8

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -2,6 +2,7 @@
 %_gpg_path <%= gpg_path %>
 %_gpg_name <%= gpg_name %>
 
+<% if fips %>
 # Necessary since RPM 4.11 (CentoOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \
@@ -13,3 +14,4 @@
 # These are SHA256 - we use them to build packages installable in FIPS mode
 %_source_filedigest_algorithm 8
 %_binary_filedigest_algorithm 8
+<% end %>

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -3,7 +3,7 @@
 %_gpg_name <%= gpg_name %>
 
 <% if fips %>
-# Necessary since RPM 4.11 (CentoOS 7), otherwise the GPG signing
+# Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \
     gpg --force-v3-sigs --yes --no-tty --no-verbose --no-armor --batch \

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -8,9 +8,6 @@
 %define __spec_clean_post true
 %define __spec_clean_pre true
 
-# Use md5
-%define _binary_filedigest_algorithm 1
-
 # Use gzip payload compression
 %define _binary_payload w9.gzdio
 

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -8,6 +8,11 @@
 %define __spec_clean_post true
 %define __spec_clean_pre true
 
+<% if not fips %>
+# Use md5
+%define _binary_filedigest_algorithm 1
+<% end %>
+
 # Use gzip payload compression
 %define _binary_payload w9.gzdio
 


### PR DESCRIPTION
This PR implements the possibility to build FIPS-installable RPMs, when RPM >= 4.14 is installed. It also preserves the previous functionality for RPM < 4.14.

Note that for now, we automatically assume that we want to build a FIPS-installable RPM when a new enough version of RPM is available. If that ever doesn't seem to hold true, we can change that with a followup PR that would introduce a configuration value for FIPS.