### PR TITLE
[backport] Use a stricter pin for ffi-yajl

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "aws-sdk",          "~> 2.11.8"
   gem.add_dependency "thor",             "~> 0.18"
-  gem.add_dependency "ffi-yajl",         "~> 2.3"
+  gem.add_dependency "ffi-yajl",         "~> 2.3.4"
   gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency 'httparty'


### PR DESCRIPTION
### Description

Backport of #117.

ffi-yajl 2.4.0 was released a few hours ago: https://rubygems.org/gems/ffi-yajl/versions/2.4.0-universal-java. This version changes the libyajl2 dependency to a more lenient one (~> 1.2 became >= 1.2), which is currently breaking Windows builds.

This PR reverts the dependency to its previous version for now (to fix builds on master & for the current release). Properly updating ffi-yajl will be done in a future PR.