### PR TITLE
Copy debug package in workspace at the end of builds

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -372,8 +372,17 @@ module Omnibus
     # --------------------------------------------------
 
     # @see Base#package_name
-    def package_name
-      bundle_msi ? bundle_name : msi_name
+    def package_name(debug = false)
+      if debug
+        debug_zip_name
+      else
+        bundle_msi ? bundle_name : msi_name
+      end
+    end
+
+    def debug_zip_name
+      # HACK: needs to match the name used in Stripper.strip_windows
+      "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{Config.windows_arch}.debug.zip"
     end
 
     def msi_name

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -382,6 +382,9 @@ module Omnibus
 
     def debug_zip_name
       # HACK: needs to match the name used in Stripper.strip_windows
+      # TODO: the debug zup on Windows should be packaged by the packager, not by the
+      # Stripper.strip_windows method, to be aligned with what's done on Linux
+      # + to remove this hack.
       "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{Config.windows_arch}.debug.zip"
     end
 

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -382,7 +382,7 @@ module Omnibus
 
     def debug_zip_name
       # HACK: needs to match the name used in Stripper.strip_windows
-      # TODO: the debug zup on Windows should be packaged by the packager, not by the
+      # TODO: the debug zip on Windows should be packaged by the packager, not by the
       # Stripper.strip_windows method, to be aligned with what's done on Linux
       # + to remove this hack.
       "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{Config.windows_arch}.debug.zip"

--- a/lib/omnibus/packagers/zip.rb
+++ b/lib/omnibus/packagers/zip.rb
@@ -104,6 +104,12 @@ module Omnibus
       zip_name
     end
 
+    # @see Base#debug_build?
+    # The zip packager doesn't support debug packaging
+    def debug_build?
+      false
+    end
+
     def zip_name
       "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{Config.windows_arch}.zip"
     end

--- a/lib/omnibus/packagers/zip.rb
+++ b/lib/omnibus/packagers/zip.rb
@@ -106,6 +106,10 @@ module Omnibus
 
     # @see Base#debug_build?
     # The zip packager doesn't support debug packaging
+    # HACK: This is needed to avoid failures when the Project#package_me method tries
+    # to fetch the debug package produced by each packager,
+    # as the Windows build uses both the MSI packager (which does have a debug package) and
+    # the ZIP packager (which doesn't have a debug package).
     def debug_build?
       false
     end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1399,6 +1399,12 @@ module Omnibus
         package_path = File.join(Config.package_dir, packager.package_name)
         FileUtils.cp(package_path, destination, preserve: true)
         FileUtils.cp("#{package_path}.metadata.json", destination, preserve: true)
+
+        # If we also generate a debug package, copy it back into the workspace
+        if packager.debug_build?
+          debug_package_path = File.join(Config.package_dir, packager.package_name(true))
+          FileUtils.cp(debug_package_path, destination, preserve: true)
+        end
       end
     end
 


### PR DESCRIPTION
### Description

Follow-up of #91 and #109. When building debug packages, copy them back in the `$WORKING_DIR/pkg` folder.

### Motivation

Get all artifacts in the same project folder at the end of the build: the debug packages were missing from it.