### PR TITLE
[licensing] try to handle the third-party dependencies we have in the datadog-agent repo

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -832,6 +832,26 @@ module Omnibus
     expose :license
 
     #
+    # Set or retrieve additional {#third_party_licenses} of the project.
+    #
+    # @example
+    #   third_party_licenses 'LiCENSES/third-party.csv'
+    #
+    # @param [String] val
+    #   the location to the CSV file with the additional third party license list.
+    #
+    # @return [String]
+    #
+    def third_party_licenses(val = NULL)
+      if null?(val)
+        @third_party_licenses || "Unspecified"
+      else
+        @third_party_licenses = val
+      end
+    end
+    expose :third_party_licenses
+
+    #
     # Set or retrieve the location of the {#license_file}
     # of the project.  It can either be a relative path inside
     # the project source directory or a URL.

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -835,7 +835,7 @@ module Omnibus
     # Set or retrieve additional {#third_party_licenses} of the project.
     #
     # @example
-    #   third_party_licenses 'LiCENSES/third-party.csv'
+    #   third_party_licenses 'LICENSES/third-party.csv'
     #
     # @param [String] val
     #   the location to the CSV file with the additional third party license list.

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -839,6 +839,10 @@ module Omnibus
     #
     # @param [String] val
     #   the location to the CSV file with the additional third party license list.
+    #   The expected format to the CSV is as follows:
+    #
+    #   Component,Origin,License
+    #   core,"github.com/DataDog/foo/bar",BSD-3-Clause
     #
     # @return [String]
     #


### PR DESCRIPTION
### Description

The goal of this PR is provide additional licensing information, if desired, via the `third_party_license` method. It expects a CSV, with the format available here: https://github.com/DataDog/datadog-agent/blob/master/LICENSE-3rdparty.csv. The goal is to include such information in the `LICENSE` bundled with the final artifacts with the goal of explicitly acknowledging and listing all licensing requirements. 
