### PR TITLE
Backport: Retry git network operations by default

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -151,7 +151,9 @@ module Omnibus
     # @return [void]
     #
     def git_clone
-      git("clone#{" --recursive" if clone_submodules?} #{source_url} .")
+      retry_block("git clone", [CommandTimeout, CommandFailed]) do
+        git("clone#{" --recursive" if clone_submodules?} #{source_url} .")
+      end
     end
 
     #
@@ -164,7 +166,11 @@ module Omnibus
       # default when a sha1 is provided).  git older than 1.7.5 doesn't
       # support the --detach flag.
       git("checkout #{resolved_version} -f -q")
-      git("submodule update --recursive") if clone_submodules?
+      if clone_submodules?
+        retry_block("git submodule update", [CommandTimeout, CommandFailed]) do
+          git("submodule update --recursive")
+        end
+      end
     end
 
     #
@@ -175,7 +181,9 @@ module Omnibus
     def git_fetch
       fetch_cmd = "fetch #{source_url} #{described_version}"
       fetch_cmd << " --recurse-submodules=on-demand" if clone_submodules?
-      git(fetch_cmd)
+      retry_block("git fetch", [CommandTimeout, CommandFailed]) do
+        git(fetch_cmd)
+      end
     end
 
     #
@@ -284,7 +292,10 @@ module Omnibus
       # allows us to return the SHA of the tagged commit for annotated
       # tags. We take care to only return exact matches in
       # process_remote_list.
-      remote_list = shellout!("git ls-remote \"#{source[:git]}\" \"#{ref}*\"").stdout
+      remote_list = retry_block("git ls-remote", [CommandTimeout, CommandFailed]) do
+        shellout!("git ls-remote \"#{source[:git]}\" \"#{ref}*\"").stdout
+      end
+
       commit_ref = dereference_annotated_tag(remote_list, ref)
 
       unless commit_ref

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -120,6 +120,34 @@ module Omnibus
     end
 
     #
+    # Retry the given block if a retriable exception is
+    # raised. Returns the value of the block call if successful.
+    #
+    # @param [String] logstr
+    #   Description of the action being retried. Used in log output.
+    #
+    # @param [Array<Exception>] retried_exceptions
+    #   List of exceptions to retry.  Any other exceptions are raisesd.
+    #
+    # @param [Integer] retries
+    #   Number of times to retry the given block.
+    #
+    def retry_block(logstr, retried_exceptions = [], retries = Omnibus::Config.fetcher_retries, &block)
+      yield
+    rescue Exception => e
+      raise e unless retried_exceptions.any? { |eclass| e.is_a?(eclass) }
+ 
+      if retries != 0
+        log.info(log_key) { "Retrying failed #{logstr} due to #{e} (#{retries} retries left)..." }
+        retries -= 1
+        retry
+      else
+        log.error(log_key) { "#{logstr} failed - #{e.class}!" }
+        raise
+      end
+    end
+
+    #
     # Convert the given path to be appropiate for shelling out on Windows.
     #
     # @param [String, Array<String>] pieces

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -136,7 +136,7 @@ module Omnibus
       yield
     rescue Exception => e
       raise e unless retried_exceptions.any? { |eclass| e.is_a?(eclass) }
- 
+
       if retries != 0
         log.info(log_key) { "Retrying failed #{logstr} due to #{e} (#{retries} retries left)..." }
         retries -= 1


### PR DESCRIPTION
Backports https://github.com/chef/omnibus/commit/35728d5bc8f6debaf3c2b423ef56b47bc3f6af7e

Should address flakes due to network errors when cloning git repos.
