### PR TITLE
Unpin ffi gem

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -36,8 +36,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency 'httparty'
-  # Pin ffi (dep of ohai) to a version that can be compiled with older autoconfs
-  gem.add_dependency "ffi",              "= 1.9.18"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"


### PR DESCRIPTION
Pinned version needs Ruby < 2.5