### PR TITLE
[licensing] Multiple fixes to ship_license

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -16,6 +16,7 @@
 
 require "fileutils"
 require "mixlib/shellout"
+require "omnibus/download_helpers"
 require "ostruct"
 require "pathname"
 require "httparty"
@@ -24,6 +25,7 @@ module Omnibus
   class Builder
     include Cleanroom
     include Digestable
+    include DownloadHelpers
     include Instrumentation
     include Logging
     include Templating
@@ -814,10 +816,8 @@ module Omnibus
         path = (known_licenses.key? source) ? known_licenses[source] : source
         destination = "#{dir_name}/" + path.split("/")[-1]
         if path.start_with? "http"
-          File.open(destination, "wb") do |f|
-            log.info(log_key) { "Downloading license file from #{path} to #{destination}" }
-            f.write HTTParty.get(path).parsed_response
-          end
+          log.info(log_key) { "Downloading license file from #{path} to #{destination}" }
+          download_file!(path, destination)
         else
           Dir.chdir(software.project_dir) do
             log.info(log_key) { "Moving license file from #{path} to #{destination}" }


### PR DESCRIPTION
### Description

Fixes the `ship_license` method, which had two issues:
- no retries in case of network errors,
- does not fail if the target URL returns a 4xx error (`HTTParty.get(path)` only fail on network errors)

This led to failed Agent builds because of intermittent network errors.

This PR replaces the download logic by the use of `download_file!`, which retries the download 5 times before giving up, and fails when it receives a 4xx response.
