### PR TITLE
Add support for runtime script dependencies in RPM

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -421,7 +421,6 @@ module Omnibus
       script_dependencies = project.runtime_script_dependencies
       if debug
         pkg_dependencies = ["#{safe_base_package_name} = #{safe_epoch}:#{safe_version}-#{safe_build_iteration}"]
-        script_dependencies = {}
       end
 
       # Get a list of all files

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -418,8 +418,10 @@ module Omnibus
       end
 
       pkg_dependencies = project.runtime_dependencies
+      script_dependencies = project.runtime_script_dependencies
       if debug
         pkg_dependencies = ["#{safe_base_package_name} = #{safe_epoch}:#{safe_version}-#{safe_build_iteration}"]
+        script_dependencies = {}
       end
 
       # Get a list of all files
@@ -447,6 +449,7 @@ module Omnibus
                         conflicts: project.conflicts,
                         replaces: project.replaces,
                         dependencies: pkg_dependencies,
+                        script_dependencies: script_dependencies,
                         user: project.package_user,
                         group: project.package_group,
                         scripts: scripts,

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -712,6 +712,28 @@ module Omnibus
     end
     expose :runtime_recommended_dependency
 
+    #
+    # Add a package that is a runtime dependency of a script of this project.
+    #
+    # @example
+    #   runtime_recommended_dependency :preinst, 'foo'
+    #   runtime_recommended_dependency :postinst, 'bar'
+    #
+    # @param [String] script
+    #   the script that requires this runtime dependency
+    # @param [String] val
+    #   the name of the script runtime dependency
+    #
+    # @return [Hash<Symbol, Array<String>>]
+    #   the list of script runtime dependencies
+    #
+    def runtime_script_dependency(script, val)
+      runtime_script_dependencies[script] ||= []
+      runtime_script_dependencies[script] << val
+      runtime_script_dependencies.dup
+    end
+    expose :runtime_recommended_dependency
+
     # Add package(s) that this project extends.
     #
     # Use this to avoid packaging many files and libraries already included by
@@ -1159,6 +1181,15 @@ module Omnibus
     #
     def runtime_recommended_dependencies
       @runtime_recommended_dependencies ||= []
+    end
+
+    #
+    # The hash of scripts software dependencies for this project.
+    #
+    # @return [Hash<Symbol>, Array<String>]
+    #
+    def runtime_script_dependencies
+      @runtime_script_dependencies ||= {}
     end
 
     # The list of packages this project extends.

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -716,8 +716,8 @@ module Omnibus
     # Add a package that is a runtime dependency of a script of this project.
     #
     # @example
-    #   runtime_recommended_dependency :preinst, 'foo'
-    #   runtime_recommended_dependency :postinst, 'bar'
+    #   runtime_script_dependency :preinst, 'foo'
+    #   runtime_script_dependency :postinst, 'bar'
     #
     # @param [String] script
     #   the script that requires this runtime dependency
@@ -732,7 +732,7 @@ module Omnibus
       runtime_script_dependencies[script] << val
       runtime_script_dependencies.dup
     end
-    expose :runtime_recommended_dependency
+    expose :runtime_script_dependency
 
     # Add package(s) that this project extends.
     #

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -35,6 +35,11 @@ Packager: <%= maintainer %>
 <% dependencies.each do |name| -%>
 Requires: <%= name %>
 <% end -%>
+<% script_dependencies.each do |script, script_deps_list| -%>
+<% script_deps_list.each do |name| -%>
+Requires(<%= script %>): <%= name %>
+<% end -%>
+<% end -%>
 <% conflicts.each do |name| -%>
 Conflicts: <%= name %>
 <% end -%>


### PR DESCRIPTION
This will allow the datadog-agent package to have `Requires(<scriptlet-type>): <dependency>` kind of dependencies, so we can properly define package script dependencies.