### PR TITLE
Remove insecure hashes

### DIFF
--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -36,7 +36,7 @@ module Omnibus
     # @return [String]
     #   the hexdigest of the file at the path
     #
-    def digest(path, type = :md5)
+    def digest(path, type = :sha256)
       digest = digest_from_type(type)
 
       update_with_file_contents(digest, path)
@@ -68,7 +68,7 @@ module Omnibus
     # @return [String]
     #   the hexdigest of the directory
     #
-    def digest_directory(path, type = :md5, options = {})
+    def digest_directory(path, type = :sha256, options = {})
       digest = digest_from_type(type)
       log.info(log_key) { "Digesting #{path} with #{type}" }
       FileSyncer.all_files_under(path, options).each do |filename|

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -31,7 +31,7 @@ module Omnibus
     ALL_EXTENSIONS = WIN_7Z_EXTENSIONS + TAR_EXTENSIONS
 
     # Digest types used for verifying file checksums
-    DIGESTS = [:sha512, :sha256, :sha1, :md5]
+    DIGESTS = [:sha512, :sha256]
 
     #
     # A fetch is required if the downloaded_file (such as a tarball) does not

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -47,8 +47,6 @@ module Omnibus
         data = {
           # Package
           basename: package.name,
-          md5: package.md5,
-          sha1: package.sha1,
           sha256: package.sha256,
           sha512: package.sha512,
           platform: platform_shortname,

--- a/lib/omnibus/package.rb
+++ b/lib/omnibus/package.rb
@@ -45,24 +45,6 @@ module Omnibus
     end
 
     #
-    # The MD5 checksum for this file.
-    #
-    # @return [String]
-    #
-    def md5
-      @md5 ||= digest(path, :md5)
-    end
-
-    #
-    # The SHA1 checksum for this file.
-    #
-    # @return [String]
-    #
-    def sha1
-      @sha1 ||= digest(path, :sha1)
-    end
-
-    #
     # The SHA256 checksum for this file.
     #
     # @return [String]

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -367,7 +367,7 @@ module Omnibus
         ]
         unless extra_keys.empty?
           raise InvalidValue.new(:source,
-                                 "only include valid keys. Invalid keys: #{extra_keys.inspect}")
+                                 "only include valid keys for software '#{name}'. Invalid keys: #{extra_keys.inspect}")
         end
 
         duplicate_keys = val.keys & [:git, :path, :url]

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -360,7 +360,7 @@ module Omnibus
 
         extra_keys = val.keys - [
           :git, :path, :url, # fetcher types
-          :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
+          :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
           :options, # used by path_fetcher
           :submodules, :always_fetch_tags # used by git_fetcher


### PR DESCRIPTION
Some changes to help us get rid of broken hashes in software definitions:
- **Remove md5 and sha1 as possible checksum hashes**: This way omnibus will fail if we try to download software that doesn't have a sha256 or better checksum.
- **Use sha256 instead of md5 as default argument for file and folder digests**: This should be a noop since every current call to `digest` and `digest_folder` does explicitly pass the desired hash as an argument.
- **Specify the software definition when an invalid field is found**: Turn the error message `Expected source to only include valid keys. Invalid keys: [:md5]` into `Expected source to only include valid keys for software 'libffi'. Invalid keys: [:md5]`