### PR TITLE
Move install dir to the staging dir of the MSI packager

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -22,7 +22,17 @@ module Omnibus
   class Packager::MSI < Packager::WindowsBase
     id :msi
 
+    # Override the default install dir to place the install files in
+    # the staging directory. That way we can modify it as we want and it won't
+    # impact other packagers, and Omnibus will take care of cleaning it for us after the build.
+    def install_dir
+      "#{staging_dir}\\install_dir"
+    end
+
     setup do
+      # Create a copy of the install directory
+      FileUtils.copy_entry windows_safe_path(project.install_dir), windows_safe_path(install_dir)
+
       if bundle_msi
         helper_tmp_dir = Dir.mktmpdir
         parameters.store('HelperDir', helper_tmp_dir)


### PR DESCRIPTION
### Description
This PR moves the `install_dir` location of the MSI packager to its `staging_dir`. That way any changes made to the install files in the context of the packager won't impact other packagers (i.e. the Zip packager).