### PR TITLE
[packagers/windows_base] Retry timestamp servers signing

### DIFF
--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -132,7 +132,7 @@ module Omnibus
     # @param [Integer] retries
     #   Number of times to retry the given block.
     #
-    def retry_block(logstr, retried_exceptions = [], retries = Omnibus::Config.fetcher_retries, &block)
+    def retry_block(logstr, retried_exceptions = [], retries = Omnibus::Config.fetcher_retries, delay = 0, &block)
       yield
     rescue Exception => e
       raise e unless retried_exceptions.any? { |eclass| e.is_a?(eclass) }
@@ -140,6 +140,7 @@ module Omnibus
       if retries != 0
         log.info(log_key) { "Retrying failed #{logstr} due to #{e} (#{retries} retries left)..." }
         retries -= 1
+        sleep(delay)
         retry
       else
         log.error(log_key) { "#{logstr} failed - #{e.class}!" }


### PR DESCRIPTION
### Description

Updates the Windows signing logic to retry multiple times, in case the signing fails (notably due to failures to connect to timestamp servers, which we don't control).

Mitigates failures due to runners failing to reach timestamp servers, therefore improving the reliability of the build.

Example pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/7549906
Example jobs where this proved useful (see raw logs): https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/127349543/raw, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/127349540/raw