### PR TITLE
Use recommended timestamp servers

### DIFF
--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -17,8 +17,10 @@
 module Omnibus
   class Packager::WindowsBase < Packager::Base
     DEFAULT_TIMESTAMP_SERVERS = ["http://timestamp.digicert.com",
-                                 "http://timestamp.verisign.com/scripts/timestamp.dll",
-                                 "http://timestamp.globalsign.com/scripts/timstamp.dll"]
+                                 "http://timestamp.globalsign.com/scripts/timstamp.dll",
+                                 "http://timestamp.comodoca.com/authenticode",
+                                 "http://www.startssl.com/timestamp",
+                                 "http://timestamp.sectigo.com"]
 
     #
     # Set the signing certificate name

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -16,6 +16,8 @@
 
 module Omnibus
   class Packager::WindowsBase < Packager::Base
+    # Only use timestamp servers from Microsoft-approved authenticode providers
+    # See https://docs.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures
     DEFAULT_TIMESTAMP_SERVERS = ["http://timestamp.digicert.com",
                                  "http://timestamp.globalsign.com/scripts/timstamp.dll",
                                  "http://timestamp.comodoca.com/authenticode",


### PR DESCRIPTION
Microsoft recommends a list of authenticode issuers, see https://docs.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures
Verisign's server has been deprecated and should be removed (probably what was causing the signing issues in the first place).