### PR TITLE
[fetchers] add the FileFetcher for `file:` sources

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -69,6 +69,7 @@ module Omnibus
   autoload :NetFetcher,  "omnibus/fetchers/net_fetcher"
   autoload :NullFetcher, "omnibus/fetchers/null_fetcher"
   autoload :PathFetcher, "omnibus/fetchers/path_fetcher"
+  autoload :FileFetcher, "omnibus/fetchers/file_fetcher"
 
   autoload :ArtifactoryPublisher, "omnibus/publishers/artifactory_publisher"
   autoload :NullPublisher,        "omnibus/publishers/null_publisher"

--- a/lib/omnibus/fetcher.rb
+++ b/lib/omnibus/fetcher.rb
@@ -196,6 +196,8 @@ module Omnibus
           GitFetcher
         elsif source[:path]
           PathFetcher
+        elsif source[:file]
+          FileFetcher
         end
       else
         NullFetcher

--- a/lib/omnibus/fetchers/file_fetcher.rb
+++ b/lib/omnibus/fetchers/file_fetcher.rb
@@ -1,0 +1,131 @@
+#
+# Copyright 2012-2018 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "fileutils" unless defined?(FileUtils)
+
+module Omnibus
+  class FileFetcher < Fetcher
+    #
+    # Fetch if the local file checksum is different than the path file
+    # checksum.
+    #
+    # @return [true, false]
+    #
+    def fetch_required?
+      target_shasum != destination_shasum
+    end
+
+    #
+    # The version identifier for this file. This is computed using the file
+    # on disk to the source and the shasum of that file on disk.
+    #
+    # @return [String]
+    #
+    def version_guid
+      "file:#{source_file}"
+    end
+
+    #
+    # Clean the given path by removing the project directory.
+    #
+    # @return [true, false]
+    #   true if the directory was cleaned, false otherwise.
+    #   Since we do not currently use the cache to sync files and
+    #   always fetch from source, there is no need to clean anything.
+    #   The fetch step (which needs to be called before clean) would
+    #   have already removed anything extraneous.
+    #
+    def clean
+      true
+    end
+
+    #
+    # Fetch any new files by copying them to the +project_dir+.
+    #
+    # @return [void]
+    #
+    def fetch
+      log.info(log_key) { "Copying from `#{source_file}'" }
+
+      create_required_directories
+      FileUtils.cp(source_file, target_file)
+      # Reset target shasum on every fetch
+      @target_shasum = nil
+      target_shasum
+    end
+
+    #
+    # The version for this item in the cache. The is the shasum of the file
+    # on disk.
+    #
+    # This method is called *before* clean but *after* fetch. Since fetch
+    # automatically cleans, target vs. destination sha doesn't matter. Change this
+    # if that assumption changes.
+    #
+    # @return [String]
+    #
+    def version_for_cache
+      "file:#{source_file}|shasum:#{destination_shasum}"
+    end
+
+    #
+    # @return [String, nil]
+    #
+    def self.resolve_version(version, source)
+      version
+    end
+
+    private
+
+    #
+    # The path on disk to pull the file from.
+    #
+    # @return [String]
+    #
+    def source_file
+      source[:file]
+    end
+
+    #
+    # The path on disk where the file is stored.
+    #
+    # @return [String]
+    #
+    def target_file
+      File.join(project_dir, File.basename(source_file))
+    end
+
+    #
+    # The shasum of the file **inside** the project.
+    #
+    # @return [String, nil]
+    #
+    def target_shasum
+      @target_shasum ||= digest(target_file, :sha256)
+    rescue Errno::ENOENT
+      @target_shasum = nil
+    end
+
+    #
+    # The shasum of the file **outside** of the project.
+    #
+    # @return [String]
+    #
+    def destination_shasum
+      @destination_shasum ||= digest(source_file, :sha256)
+    end
+  end
+end

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -232,7 +232,7 @@ module Omnibus
           # file to live **inside** the project directory. project_dir should already
           # exist due to create_required_directories
           log.info(log_key) { "`#{safe_downloaded_file}' is a regular file - naming copy `#{target_filename}'" }
-          FileUtils.cp(downloaded_file, File.join(project_dir, target_filename))
+          FileUtils.cp(downloaded_file, File.join(project_dir, File.basename(target_filename)))
         end
       end
       if ship_source?

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -62,10 +62,10 @@ module Omnibus
     #
     def fetch
       log.info(log_key) { "Copying from `#{source_path}'" }
-      raise "we are about to fetch\!"
 
       @@source_path_mutexes[source_path].synchronize {
         create_required_directories
+        raise "we are about to sync #{source_path} for #{project_dir} with #{source_options}\!"
         FileSyncer.sync(source_path, project_dir, source_options)
         # Reset target shasum on every fetch
         @target_shasum = nil

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -65,7 +65,6 @@ module Omnibus
 
       @@source_path_mutexes[source_path].synchronize {
         create_required_directories
-        raise "we are about to sync #{source_path} for #{project_dir} with #{source_options}\!"
         FileSyncer.sync(source_path, project_dir, source_options)
         # Reset target shasum on every fetch
         @target_shasum = nil

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -27,7 +27,8 @@ module Omnibus
     # @return [true, false]
     #
     def fetch_required?
-      target_shasum != destination_shasum
+      # target_shasum != destination_shasum
+      true
     end
 
     #
@@ -61,6 +62,7 @@ module Omnibus
     #
     def fetch
       log.info(log_key) { "Copying from `#{source_path}'" }
+      raise "we are about to fetch\!"
 
       @@source_path_mutexes[source_path].synchronize {
         create_required_directories

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -27,8 +27,7 @@ module Omnibus
     # @return [true, false]
     #
     def fetch_required?
-      # target_shasum != destination_shasum
-      true
+      target_shasum != destination_shasum
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -359,7 +359,7 @@ module Omnibus
         val = canonicalize_source(val)
 
         extra_keys = val.keys - [
-          :git, :path, :url, # fetcher types
+          :git, :path, :url, :file # fetcher types
           :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
           :options, # used by path_fetcher
@@ -370,7 +370,7 @@ module Omnibus
                                  "only include valid keys for software '#{name}'. Invalid keys: #{extra_keys.inspect}")
         end
 
-        duplicate_keys = val.keys & [:git, :path, :url]
+        duplicate_keys = val.keys & [:git, :path, :url, :file]
         unless duplicate_keys.size < 2
           raise InvalidValue.new(:source,
                                  "not include duplicate keys. Duplicate keys: #{duplicate_keys.inspect}")

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -359,7 +359,7 @@ module Omnibus
         val = canonicalize_source(val)
 
         extra_keys = val.keys - [
-          :git, :path, :url, :file # fetcher types
+          :git, :path, :url, :file, # fetcher types
           :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
           :options, # used by path_fetcher


### PR DESCRIPTION
### Description

This PR adds the FileFetcher to omnibus such that we can use local filesystem files on builds. This is useful because we can use artifacts from previous gitlab stages as sources for a certain build. The PathFetcher was causing issues (ie. not working), and this seemed the path of least resistance. 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
