### PR TITLE
[health_check] Remove libcrypt from allowlisted libraries

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -30,7 +30,6 @@ module Omnibus
     WHITELIST_LIBS = [
       /ld-linux/,
       /libc\.so/,
-      /libcrypt\.so/,
       /libdb-4.5\.so/,
       /libdb-4.7\.so/,
       /libdb-5.3\.so/,


### PR DESCRIPTION
### Description

Removes `libcrypt.so` from the list of allowlisted library matches in the health check.
Some newer OS versions do not bundle `libcrypt.so.1`, so we can't assume that it is always going to be there anymore.