### PR TITLE
[RPM] Decouple GPG key name from maintainer (#110)

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -87,8 +87,30 @@ module Omnibus
     # --------------------------------------------------
 
     #
-    # Set or return the signing passphrase. If this value is provided,
-    # Omnibus will attempt to sign the RPM.
+    # Set or return the the gpg key name to use while signing.
+    # If this value is provided, Omnibus will attempt to sign the RPM.
+    #
+    # @example
+    #   gpg_key_name 'My key <my.address@here.com>'
+    #
+    # @param [String] val
+    #   the name of the GPG key to use during RPM signing
+    #
+    # @return [String]
+    #   the RPM signing GPG key name
+    #
+    def gpg_key_name(val = NULL)
+      if null?(val)
+        @gpg_key_name
+      else
+        @gpg_key_name = val
+      end
+    end
+    expose :gpg_key_name
+
+    #
+    # Set or return the signing passphrase.
+    # If this value is provided, Omnibus will attempt to sign the RPM.
     #
     # @example
     #   signing_passphrase "foo"
@@ -387,8 +409,11 @@ module Omnibus
       command << %{ --buildroot #{staging_dir}/BUILD}
       command << %{ --define '_topdir #{staging_dir}'}
 
-      if signing_passphrase
+      if gpg_key_name || signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
+
+        key_name = gpg_key_name || project.maintainer
+        log.info(log_key) { "Using gpg key #{key_name}" }
 
         if File.exist?("#{ENV['HOME']}/.rpmmacros")
           log.info(log_key) { "Detected .rpmmacros file at `#{ENV['HOME']}'" }
@@ -402,7 +427,7 @@ module Omnibus
           render_template(resource_path("rpmmacros.erb"),
             destination: "#{home}/.rpmmacros",
             variables: {
-              gpg_name: project.maintainer,
+              gpg_name: key_name,
               gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
             }
           )


### PR DESCRIPTION
Creates a new RPM Packager field, gpg_key_name, to specify a GPG key name that's different from the maintainer name. If not specified, project.maintainer is still used.

### Description

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
