### PR TITLE
[Pipeline/Tooling] SUSE RPMs are now signed in SHA256

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -32,6 +32,7 @@ module Omnibus
       /libc\.so/,
       /libdb-4.5\.so/,
       /libdb-4.7\.so/,
+      /libdb-4.8\.so/,
       /libdb-5.3\.so/,
       /libdl/,
       /libfreebl\d\.so/,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -492,8 +492,8 @@ module Omnibus
           # Generate a temporary home directory
           home = Dir.mktmpdir
         end
-        recent_version = rpm_version()[:minor].to_i >= 14 ? true : false
-        if recent_version
+        rpm_414_or_later = rpm_version()[:minor].to_i >= 14 ? true : false
+        if rpm_414_or_later
           with_rpm_passphrase do |passphrase_file|
             if not has_rpmmacros
               gpg_extra_args = ""
@@ -509,7 +509,7 @@ module Omnibus
                                 gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
                                 gpg_passphrase_file: passphrase_file,
                                 gpg_extra_args: gpg_extra_args,
-                                recent_version: true,
+                                rpm_414_or_later: true,
                               })
             end
 
@@ -528,7 +528,7 @@ module Omnibus
                             variables: {
                               gpg_name: key_name,
                               gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
-                              recent_version: false,
+                              rpm_414_or_later: false,
                             })
           end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -98,20 +98,18 @@ module Omnibus
         raise Error.new("Only works with RPM 4")
       end
 
-      fips = rv[:minor].to_i >= 14 ? true : false
-
       # Generate the spec
-      write_rpm_spec(fips)
+      write_rpm_spec()
 
       # Generate the rpm
-      create_rpm_file(fips)
+      create_rpm_file()
 
       if debug_build?
         # Generate the spec
-        write_rpm_spec(fips, true)
+        write_rpm_spec(true)
 
         # Generate the rpm
-        create_rpm_file(fips, true)
+        create_rpm_file(true)
       end
     end
 
@@ -401,7 +399,7 @@ module Omnibus
     #
     # @return [void]
     #
-    def write_rpm_spec(fips, debug = false)
+    def write_rpm_spec(debug = false)
       # Create a map of scripts that exist and their contents
       scripts = SCRIPT_MAP.inject({}) do |hash, (source, destination)|
         script_src = source.to_s
@@ -456,7 +454,6 @@ module Omnibus
                         files: files,
                         build_dir: build_dir(debug),
                         platform_family: Ohai["platform_family"],
-                        fips: fips,
                       })
     end
 
@@ -467,7 +464,7 @@ module Omnibus
     #
     # @return [void]
     #
-    def create_rpm_file(fips, debug = false)
+    def create_rpm_file(debug = false)
       stage = staging_dir
       if debug
         stage = staging_dbg_dir
@@ -495,8 +492,8 @@ module Omnibus
           # Generate a temporary home directory
           home = Dir.mktmpdir
         end
-
-        if fips
+        recent_version = rpm_version()[:minor].to_i >= 14 ? true : false
+        if recent_version
           with_rpm_passphrase do |passphrase_file|
             if not has_rpmmacros
               gpg_extra_args = ""
@@ -512,7 +509,7 @@ module Omnibus
                                 gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
                                 gpg_passphrase_file: passphrase_file,
                                 gpg_extra_args: gpg_extra_args,
-                                fips: true,
+                                recent_version: true,
                               })
             end
 
@@ -531,7 +528,7 @@ module Omnibus
                             variables: {
                               gpg_name: key_name,
                               gpg_path: "#{ENV['HOME']}/.gnupg", # TODO: Make this configurable
-                              fips: false,
+                              recent_version: false,
                             })
           end
 

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -6,7 +6,7 @@
 %_source_filedigest_algorithm 8
 %_binary_filedigest_algorithm 8
 
-<% if recent_version %>
+<% if rpm_414_or_later %>
 # Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -2,6 +2,10 @@
 %_gpg_path <%= gpg_path %>
 %_gpg_name <%= gpg_name %>
 
+# These are SHA256 
+%_source_filedigest_algorithm 8
+%_binary_filedigest_algorithm 8
+
 <% if fips %>
 # Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
@@ -11,7 +15,4 @@
     --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} \
     %{__plaintext_filename} <%= gpg_extra_args %>
 
-# These are SHA256 - we use them to build packages installable in FIPS mode
-%_source_filedigest_algorithm 8
-%_binary_filedigest_algorithm 8
 <% end %>

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -6,7 +6,7 @@
 %_source_filedigest_algorithm 8
 %_binary_filedigest_algorithm 8
 
-<% if new_version %>
+<% if recent_version %>
 # Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \

--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -6,7 +6,7 @@
 %_source_filedigest_algorithm 8
 %_binary_filedigest_algorithm 8
 
-<% if fips %>
+<% if new_version %>
 # Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -8,11 +8,6 @@
 %define __spec_clean_post true
 %define __spec_clean_pre true
 
-<% if not fips %>
-# Use md5
-%define _binary_filedigest_algorithm 1
-<% end %>
-
 # Use gzip payload compression
 %define _binary_payload w9.gzdio
 


### PR DESCRIPTION
### Description

Changes : 
  - openSUSE rpms are now signed in sha256
  - whitelist updated to allow libdb4.8 (more details on this commit 7ba613e4d5cf1879ebce485b38842f1cec5b3afd)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
