### PR TITLE
[net_fetcher] Add ability to ship source offers

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -140,6 +140,15 @@ module Omnibus
     end
 
     #
+    # Tells if the source offer should be shipped
+    #
+    # @return [Boolean]
+    #
+    def ship_source_offer?
+      source[:ship_source_offer]
+    end
+
+    #
     # The checksum as defined by the user in the software definition.
     #
     # @return [String]
@@ -243,6 +252,15 @@ module Omnibus
         else
           FileUtils.cp(downloaded_file, "#{sources_dir}/#{name}")
         end
+      end
+      if ship_source_offer?
+        offer = <<~EOH
+          This package ships #{name}.
+          Contact Datadog Support (http://docs.datadoghq.com/help/) to request the sources of this software."
+        EOH
+        FileUtils.mkdir_p("#{sources_dir}/#{name}")
+        log.info(log_key) { "Adding source offer in #{sources_dir}/#{name}/offer.txt" }
+        File.open("#{sources_dir}/#{name}/offer.txt", 'w') { |file| file.write(offer) }
       end
     end
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -380,6 +380,10 @@ module Omnibus
           val[:ship_source] = true
         end
 
+        if ship_source_offer
+          val[:ship_source_offer] = true
+        end
+
         @source ||= {}
         @source.merge!(val)
       end
@@ -934,6 +938,31 @@ module Omnibus
       end
     end
     expose :ship_source
+
+    #
+    # Tells if the an offer to provide sources should be shipped alongside the built
+    # software.
+    #
+    # If set to true, the source offer will be put in {sources_dir}/{software_name}
+    # by the fetcher, and will be copied to {install_dir}/sources/{software_name}
+    # by the Project which created this Software.
+    #
+    # @example
+    #   ship_source_offer true
+    #
+    # @param [Boolean] val
+    #   the new value of ship_source_offer.
+    #
+    # @return [Boolean]
+    #
+    def ship_source_offer(val = NULL)
+      if null?(val)
+        @ship_source_offer || false
+      else
+        @ship_source_offer = val
+      end
+    end
+    expose :ship_source_offer
 
     #
     # [MacOS only]


### PR DESCRIPTION
### Description

Adds a new `ship_source_offer` option for software definitions. If enabled, an offer file is added in `sources/<software definition name>/offer.txt` saying that Datadog support can be reached.

Same as `ship_source`, this option must be specified _before_ the `source` option.

### Additional notes

Long-term, the message should be configurable per-project (so the Datadog support part would be configured in the datadog-agent project). The license and version, and original download location of the software could also be added.

Test datadog-agent pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/14811155
