### PR TITLE
[Pipeline/Tooling] Move to V4 GPG signatures for RPM signing

### DIFF
--- a/resources/rpm/rpmmacros.erb
+++ b/resources/rpm/rpmmacros.erb
@@ -10,7 +10,7 @@
 # Necessary since RPM 4.11 (CentOS 7), otherwise the GPG signing
 # machinery in RPM will ask for password via pinentry.
 %__gpg_sign_cmd %{__gpg} \
-    gpg --force-v3-sigs --yes --no-tty --no-verbose --no-armor --batch \
+    gpg --yes --no-tty --no-verbose --no-armor --batch \
     --passphrase-file <%= gpg_passphrase_file %> --digest-algo sha256 \
     --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} \
     %{__plaintext_filename} <%= gpg_extra_args %>


### PR DESCRIPTION
### Description

We're moving to GPG v4 signatures, since some of our own RPM packages are already in v4 like vector or APM.


--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
