### PR TITLE
[health_check] Add libdb-4.8.so to allowlist

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -32,6 +32,7 @@ module Omnibus
       /libc\.so/,
       /libdb-4.5\.so/,
       /libdb-4.7\.so/,
+      /libdb-4.8\.so/,
       /libdb-5.3\.so/,
       /libdl/,
       /libfreebl\d\.so/,


### PR DESCRIPTION
### Description

Partial backport of #148, to make https://github.com/DataDog/datadog-agent/pull/16715 work on `7.44.x`.