### PR TITLE
Db/add new windows codesign

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -37,7 +37,7 @@ module Omnibus
         helper_tmp_dir = Dir.mktmpdir
         parameters.store('HelperDir', helper_tmp_dir)
         FileUtils.mv "#{install_dir}/bin/upgrade-helper.exe", "#{helper_tmp_dir}"
-        if signing_identity or signing_identity_file
+        if signing_identity or signing_identity_file or dd_wcssign
           Dir["#{helper_tmp_dir}" + "/**/*.{exe,dll}"].each do |signfile|
             sign_package(signfile)
           end
@@ -78,7 +78,7 @@ module Omnibus
     end
 
     build do
-      if signing_identity or signing_identity_file
+      if signing_identity or signing_identity_file or dd_wcssign
         puts "starting signing"
         if additional_sign_files
           additional_sign_files.each do |signfile|
@@ -140,7 +140,7 @@ module Omnibus
         msi_file = windows_safe_path(Config.package_dir, msi_name)
         shellout!(light_command(msi_file, wixobj_list: wixobj_list), returns: [0, 204])
 
-        if signing_identity or signing_identity_file
+        if signing_identity or signing_identity_file or dd_wcssign
           sign_package(msi_file)
         end
 
@@ -153,7 +153,7 @@ module Omnibus
           bundle_file = windows_safe_path(Config.package_dir, bundle_name)
           shellout!(light_command(bundle_file, is_bundle: true), returns: [0, 204])
 
-          if signing_identity or signing_identity_file
+          if signing_identity or signing_identity_file or dd_wcssign
             sign_package(bundle_file, is_bundle: true)
           end
         end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -189,9 +189,10 @@ module Omnibus
         if signing_identity_file
           raise Error, "You cannot specify signing_identity_file with dd_wcssign"
         end
+
         @dd_wcssign = enabled
       end
-      
+
       @dd_wcssign
     end
     expose :dd_wcssign

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -181,6 +181,17 @@ module Omnibus
       end
     end
 
+    def dd_wcssign(enabled)
+      unless !enabled
+        if signing_identity signing_identity_file
+          raise Error, "You cannot specify signing_identity or signing_identity_file with dd_wcssign"
+        end
+      end
+      @dd_wcssign = enabled
+      @dd_wcssign
+    end
+    expose :dd_wcssign
+
     #
     # Iterates through available timestamp servers and tries to sign
     # the file with with each server, stopping after the first to succeed.
@@ -218,7 +229,13 @@ module Omnibus
     end
 
     def try_sign(package_file, url)
-      if signing_identity
+      if dd_wcssign
+        cmd = Array.new.tap do |arr|
+          arr << "dd-wcs"
+          arr << "sign"
+          arr << "\"#{package_file}\""
+        end.join(" ")
+      elsif signing_identity
         cmd = Array.new.tap do |arr|
           arr << "signtool.exe"
           arr << "sign /v"

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -239,12 +239,14 @@ module Omnibus
 
     def try_sign(package_file, url)
       if dd_wcssign
+        puts "signing with dd-wcs"
         cmd = Array.new.tap do |arr|
           arr << "dd-wcs"
           arr << "sign"
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity
+        "puts signing with signtool (machine store)"
         cmd = Array.new.tap do |arr|
           arr << "signtool.exe"
           arr << "sign /v"
@@ -257,6 +259,7 @@ module Omnibus
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity_file
+        "puts signing with signtool (pfx file)"
         cmd = Array.new.tap do |arr|
           arr << "signtool.exe"
           arr << "sign /v"

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -181,13 +181,17 @@ module Omnibus
       end
     end
 
-    def dd_wcssign(enabled)
-      unless !enabled
-        if signing_identity signing_identity_file
-          raise Error, "You cannot specify signing_identity or signing_identity_file with dd_wcssign"
+    def dd_wcssign(enabled = false)
+      if enabled
+        if signing_identity
+          raise Error, "You cannot specify signing_identity with dd_wcssign"
         end
+        if signing_identity_file
+          raise Error, "You cannot specify signing_identity_file with dd_wcssign"
+        end
+        @dd_wcssign = enabled
       end
-      @dd_wcssign = enabled
+      
       @dd_wcssign
     end
     expose :dd_wcssign

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -222,11 +222,15 @@ module Omnibus
 
       retry_block("signing with timestamp servers", [FailedToSignWindowsPackage], retries = 5, delay = 5) do
         success = false
-        timestamp_servers.each do |ts|
-          puts "signing with timestamp server: #{ts}"
-          success = try_sign(safe_package_file, ts)
-          puts "signed with timestamp server: #{ts}" if success
-          break if success
+        if dd_wcssign
+          success = try_sign(safe_package_file, NULL)
+        else
+          timestamp_servers.each do |ts|
+            puts "signing with timestamp server: #{ts}"
+            success = try_sign(safe_package_file, ts)
+            puts "signed with timestamp server: #{ts}" if success
+            break if success
+          end
         end
         raise FailedToSignWindowsPackage.new if !success
       end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -246,7 +246,7 @@ module Omnibus
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity
-        "puts signing with signtool (machine store)"
+        puts "signing with signtool (machine store)"
         cmd = Array.new.tap do |arr|
           arr << "signtool.exe"
           arr << "sign /v"
@@ -259,7 +259,7 @@ module Omnibus
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity_file
-        "puts signing with signtool (pfx file)"
+        puts "signing with signtool (pfx file)"
         cmd = Array.new.tap do |arr|
           arr << "signtool.exe"
           arr << "sign /v"

--- a/lib/omnibus/packagers/zip.rb
+++ b/lib/omnibus/packagers/zip.rb
@@ -26,7 +26,7 @@ module Omnibus
     end
 
     build do
-      if signing_identity or signing_identity_file
+      if signing_identity or signing_identity_file or dd_wcssign
         puts "starting signing"
         if additional_sign_files
           additional_sign_files.each do |signfile|


### PR DESCRIPTION
### Description
Adds ability to codesign windows binaries with new dd-wcs tool

dd-wcs tool is added to the build container, and retrieves all key material from kms.