### PR TITLE
Add env vars to override the number of workers

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -586,7 +586,9 @@ module Omnibus
     #
     # @return [Integer]
     default(:workers) do
-      if Ohai["cpu"] && Ohai["cpu"]["total"]
+      if ENV.has_value?("OMNIBUS_WORKERS_OVERRIDE")
+        ENV["OMNIBUS_WORKERS_OVERRIDE"].to_i
+      elsif Ohai["cpu"] && Ohai["cpu"]["total"]
         Ohai["cpu"]["total"].to_i + 1
       else
         3


### PR DESCRIPTION
### Description

We can now use OMNIBUS_WORKERS_OVERRIDE to override the number of worker used by omnibus. This is usefull because otherwise when running on Kubernetes runners, omnibus uses all the CPU available on the host where the pod runs.
Because ohai["cpu"] return the number of CPU on the host where the pod runs.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
