### PR TITLE
Add a setting to override the targeted distribution

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -176,6 +176,8 @@ module Omnibus
     # @!endgroup
     #
 
+    default(:host_distribution, nil)
+
     #
     # @!group DMG / PKG configuration options
     # --------------------------------------------------


### PR DESCRIPTION
This allows us to specify the host distribution we want to target through the CLI