### PR TITLE
builder: upstream our cmake wrapper

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -227,6 +227,30 @@ module Omnibus
     end
     expose :configure
 
+    def cmake(*args)
+      cwd = "#{project_dir}/build"
+      options = args.last.is_a?(Hash) ? args.pop : {}
+      options = { cwd: cwd }.merge(options)
+
+      mkdir "build"
+
+      cmake_cmd = ["cmake", ".."]
+      prefix = options.delete(:prefix) || "#{install_dir}/embedded"
+      cmake_cmd << "-DCMAKE_INSTALL_PREFIX=#{prefix}" if prefix && prefix != ""
+      libdir = options.delete(:libdir) || "lib"
+      cmake_cmd << "-DCMAKE_INSTALL_LIBDIR=#{libdir}" if libdir && libdir != ""
+      rpath = options.delete(:rpath) || "#{prefix}/#{libdir}"
+      cmake_cmd << "-DCMAKE_INSTALL_RPATH=#{rpath}" if rpath && rpath != ""
+      cmake_cmd.concat args
+      cmake_cmd = cmake_cmd.join(" ").strip
+
+      command(cmake_cmd, options)
+
+      make("-j #{workers}", options)
+      make("install", options)
+    end
+    expose :cmake
+
     #
     # Apply the patch by the given name. This method will search all possible
     # locations for a patch (such as {Config#software_gems}).


### PR DESCRIPTION
### Description

This upstream the cmake wrapper from datadog-agent to our omnibus fork, so we can use it in recipes from the agent repo & omnibus-software.

The intent is to simplify tweaking the build of cmake based projects, by having a single location to edit

Tested with this pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/22116693