### PR TITLE
Fix compression settings on SUSE

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -454,6 +454,9 @@ module Omnibus
                         files: files,
                         build_dir: build_dir(debug),
                         platform_family: Ohai["platform_family"],
+                        compression_level: compression_level,
+                        compression_threads: compression_threads,
+                        compression_algo: compression_algo,
                       })
     end
 
@@ -830,5 +833,40 @@ module Omnibus
         shellout!("yum -y remove #{packages}")
       end
     end
+
+    def compression_level(val = nil)
+      unless val.nil?
+        unless val >= 0 && val <= 9
+          raise InvalidValue.new(:compression_level, 'be an Integer between 0 and 9 included')
+        end
+      end
+      @compression_level = val || 6
+    end
+    expose :compression_level
+
+    def compression_threads(val = nil)
+      unless val.nil?
+        unless val > 0 && val < 32
+          raise InvalidValue.new(:compression_threads, 'be a stricly positive and lower than 32 Integer')
+        end
+      end
+      @compression_threads = val || 1
+    end
+    expose :compression_threads
+
+    def compression_algo(val = nil)
+      unless val.nil?
+        if val == "xz"
+          val = "xzdio"
+        elsif val == "gzip"
+          val = "gzdio"
+        else
+          raise InvalidValue.new(:compression_algo, 'be one of xz or gzip')
+        end
+
+      end
+      @compression_algo = val || "gzdio"
+    end
+    expose :compression_algo
   end
 end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -844,7 +844,14 @@ module Omnibus
     end
     expose :compression_level
 
+    #
+    # Defines the number of thread that should be used to compress the package
+    # This will be ignored when compression_algo is set to gzip as this isn't
+    # supported by gzip
+    #
     def compression_threads(val = nil)
+      # Don't reject the value if compression_algo is != gzip in order to avoid
+      # forcing an ordering for the properties
       unless val.nil?
         unless val > 0 && val < 32
           raise InvalidValue.new(:compression_threads, 'be a stricly positive and lower than 32 Integer')

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -8,8 +8,8 @@
 %define __spec_clean_post true
 %define __spec_clean_pre true
 
-# Use gzip payload compression
-%define _binary_payload w9.gzdio
+# Setup payload compression
+%define _binary_payload w<%= compression_level %>T<%= compression_threads %>.<%= compression_algo %>
 
 # Metadata
 Name: <%= name %>

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -9,8 +9,8 @@
 %define __spec_clean_pre true
 
 # Setup payload compression
-<% if compression_threads != 1 %>
-%define _binary_payload w<%= compression_level %>T<%= compression_threads %>.<%= compression_algo %>
+<% if compression_threads != 1 && compression_algo == "xzdio" %>
+%define _binary_payload w<%= compression_level %>T<%= compression_threads %>.xzdio
 <% else %>
 %define _binary_payload w<%= compression_level %>.<%= compression_algo %>
 <% end %>

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -9,7 +9,11 @@
 %define __spec_clean_pre true
 
 # Setup payload compression
+<% if compression_threads != 1 %>
 %define _binary_payload w<%= compression_level %>T<%= compression_threads %>.<%= compression_algo %>
+<% else %>
+%define _binary_payload w<%= compression_level %>.<%= compression_algo %>
+<% end %>
 
 # Metadata
 Name: <%= name %>


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

Fix the change introduced in #163 that was reverted in #164 

On SUSE, it appears that specifying a number of thread set to 1 will cause the compression to be ignored/disabled

Test pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/25803790