### PR TITLE
macos: fix & reenable healthcheck

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -246,7 +246,7 @@ module Omnibus
       measure("Health check time") do
         log.info(log_key) { "Running health on #{project.name}" }
         bad_libs =  case Ohai["platform"]
-                    when "mac_os_x"
+                    when "macos"
                       health_check_otool
                     when "aix"
                       health_check_aix

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -463,7 +463,7 @@ module Omnibus
       current_library = nil
       bad_libs = {}
 
-      yield_shellout_results("find #{project.install_dir}/ -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
+      yield_shellout_results("find #{project.install_dir} -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -149,6 +149,9 @@ module Omnibus
       /libiconv/,
       /libstdc\+\+\.6\.dylib/,
       /libc\+\+\.1\.dylib/,
+      /libzstd\.1\.dylib/,
+      /Security/,
+      /SystemConfiguration/,
     ].freeze
 
     FREEBSD_WHITELIST_LIBS = [

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -494,7 +494,11 @@ module Omnibus
         when /^\s+(.+) \(.+\)?$/
           linked = Regexp.last_match[1]
           name = File.basename(linked)
-          bad_libs = check_for_bad_macos_library(bad_libs, current_library, name, linked, install_name)
+          # If this is just the install name being mentionned, but not an actually
+          # linked dependency then we have nothing to check
+          unless install_name && install_name == linked
+            bad_libs = check_for_bad_macos_library(bad_libs, current_library, name, linked)
+          end
         end
       end
 
@@ -504,7 +508,7 @@ module Omnibus
     #
     # Check the given path and library for "bad" libraries.
     #
-    def check_for_bad_macos_library(bad_libs, current_library, name, linked, install_name)
+    def check_for_bad_macos_library(bad_libs, current_library, name, linked)
       safe = nil
 
       whitelist_libs = MAC_WHITELIST_LIBS
@@ -527,13 +531,8 @@ module Omnibus
         loader_path_regexp = Regexp.new("@loader_path")
         install_dir_regexp = Regexp.new(project.install_dir)
 
-        if install_name && linked == install_name
-          # This is just the install name being mentionned, but not an actually
-          # linked dependency. As such, it is safe and we have nothing to check
-          safe = true
-          possible_paths = []
         # Do the linker's work of replacing @rpath with the rpaths defined by the library
-        elsif linked =~ rpath_regexp
+        if linked =~ rpath_regexp
           possible_paths = []
           # Find what are the library's rpaths by looking at the load commands.
           # Example otool -l partial output:

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -250,7 +250,7 @@ module Omnibus
       measure("Health check time") do
         log.info(log_key) { "Running health on #{project.name}" }
         bad_libs =  case Ohai["platform"]
-                    when "macos"
+                    when "macos", "mac_os_x"
                       health_check_otool
                     when "aix"
                       health_check_aix

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -453,6 +453,27 @@ module Omnibus
       end
     end
 
+    # Get the dylib install path if present.
+    # When present, it would confuse the healthcheck into thinking the
+    # library is linking with an identically named library, while this not the
+    # indication of any link, and it should jjust be ignored.
+    def get_macos_dylib_install_name(lib)
+      # otool -D expected output:
+      # $> otool -D ..../libddwaf.dylib
+      # /opt/datadog-agent/embedded/lib/python3.11/site-packages/ddtrace/appsec/ddwaf/libddwaf/x86_64/lib/libddwaf.dylib:
+      # @rpath/libddwaf.dylib
+      yield_shellout_results("otool -D #{lib}") do |line|
+        case line
+        when /^(.+):$/
+          # This is the name of the library we're inspecting, nothing to do here
+        when /^(.+).dylib$/
+          install_name = Regexp.last_match[0]
+          return install_name
+        end
+      end
+      return nil
+    end
+
     #
     # Run healthchecks against otool.
     #
@@ -462,15 +483,17 @@ module Omnibus
     def health_check_otool
       current_library = nil
       bad_libs = {}
+      install_name = nil
 
       yield_shellout_results("find #{project.install_dir} -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]
-        when /^\s+(.+) \(.+\)$/
+          install_name = get_macos_dylib_install_name(current_library)
+        when /^\s+(.+) \(.+\)?$/
           linked = Regexp.last_match[1]
           name = File.basename(linked)
-          bad_libs = check_for_bad_macos_library(bad_libs, current_library, name, linked)
+          bad_libs = check_for_bad_macos_library(bad_libs, current_library, name, linked, install_name)
         end
       end
 
@@ -480,7 +503,7 @@ module Omnibus
     #
     # Check the given path and library for "bad" libraries.
     #
-    def check_for_bad_macos_library(bad_libs, current_library, name, linked)
+    def check_for_bad_macos_library(bad_libs, current_library, name, linked, install_name)
       safe = nil
 
       whitelist_libs = MAC_WHITELIST_LIBS
@@ -503,8 +526,13 @@ module Omnibus
         loader_path_regexp = Regexp.new("@loader_path")
         install_dir_regexp = Regexp.new(project.install_dir)
 
+        if install_name && linked == install_name
+          # This is just the install name being mentionned, but not an actually
+          # linked dependency. As such, it is safe and we have nothing to check
+          safe = true
+          possible_paths = []
         # Do the linker's work of replacing @rpath with the rpaths defined by the library
-        if linked =~ rpath_regexp
+        elsif linked =~ rpath_regexp
           possible_paths = []
           # Find what are the library's rpaths by looking at the load commands.
           # Example otool -l partial output:

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -152,6 +152,7 @@ module Omnibus
       /libzstd\.1\.dylib/,
       /Security/,
       /SystemConfiguration/,
+      /libresolv\.9\.dylib/,
     ].freeze
 
     FREEBSD_WHITELIST_LIBS = [


### PR DESCRIPTION
This fixes dispatching the correct healthcheck for macOS, which hasn't run in a while
Co-authored-by: Kylian Serrania <kylian.serrania@datadoghq.com>

