### PR TITLE
Fix potential package failure when creating 2 packages in a row

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -128,6 +128,10 @@ module Omnibus
       # Ensure the destination directory exists
       create_sync_dir(source, destination)
 
+      # Clear any hardlink that we might have seen while syncing a previous directory
+      # This can happen when generating 2 different packages in a row
+      hardlink_sources.clear
+
       # Copy over the filtered source files
       source_files.each do |source_file|
         relative_path = relative_path_for(source_file, source)


### PR DESCRIPTION
Omnibus logic around hardlink didn't handle 2 packages running in a row, causing the first hardlink in the 2nd package to error out (most likely the link was still present in its hash table but the staging directory was removed, causing the linx creation to fail)

Plain failure in the bump PR: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/426264284
Failure with extra logs: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/426728037
With the fix and extra logs: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/426743506