### PR TITLE
packagers: ociru: don't attempt to merge a nil result entry

### DIFF
--- a/lib/omnibus/packagers/ociru.rb
+++ b/lib/omnibus/packagers/ociru.rb
@@ -223,7 +223,9 @@ module Omnibus
 
       filelist = {}
       results.each do |r|
-        filelist.merge(r)
+        unless r.nil?
+          filelist.merge(r)
+        end
       end
       filelist.delete("/.")
 


### PR DESCRIPTION
In the unlikely event where a worker didn't have any work scheduled, its result entry won't get a value assigned, which would cause the packager to crash.

