### PR TITLE
Compute a build duration report

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -762,11 +762,12 @@ module Omnibus
         end
       end
 
-      measure("Build #{software.name}") do
+      build_time = measure("Build #{software.name}") do
         build_commands.each do |command|
           execute(command)
         end
       end
+      software.store_build_duration(build_time)
 
       log.info(log_key) { "Finished build" }
     end

--- a/lib/omnibus/instrumentation.rb
+++ b/lib/omnibus/instrumentation.rb
@@ -24,6 +24,7 @@ module Omnibus
     ensure
       elapsed = Time.now - start
       log.info(log_key) { "#{label}: #{elapsed.to_f.round(4)}s" }
+      return elapsed
     end
   end
 end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1404,7 +1404,7 @@ module Omnibus
     end
 
     def build_summary
-      summary = {"build" => {}}
+      summary = { "build" => {} }
       softwares.each do |s|
         summary["build"][s.name] = s.build_summary
       end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -80,6 +80,7 @@ module Omnibus
     def initialize(filepath = nil, manifest = nil)
       @filepath = filepath
       @manifest = manifest
+      @package_summary = {}
     end
 
     #
@@ -1495,7 +1496,7 @@ module Omnibus
           next
         end
         # Run the actual packager
-        packager.run!
+        @package_summary[packager.id] = packager.run!
 
         # Copy the generated package and metadata back into the workspace
         package_path = File.join(Config.package_dir, packager.package_name)

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1466,8 +1466,8 @@ module Omnibus
     end
 
     def write_build_summary
-      FileUtils.mkdir_p(Config.package_dir)
-      out_path = "#{Config.package_dir}/build-summary.json"
+      out_path = "#{Config.project_root}/pkg/build-summary.json"
+      log.info(log_key) { "Writing build summary to #{out_path}" }
       File.open(out_path, "w") do |f|
         f.write(FFI_Yajl::Encoder.encode(build_summary.to_hash, pretty: true))
       end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1403,6 +1403,15 @@ module Omnibus
       m
     end
 
+    def build_summary
+      summary = {"build" => {}}
+      softwares.each do |s|
+        summary["build"][s.name] = s.build_summary
+      end
+      summary["packaging"] = @package_summary
+      summary
+    end
+
     def download
       ThreadPool.new(Config.workers) do |pool|
         softwares.each do |software|
@@ -1446,11 +1455,21 @@ module Omnibus
 
       package_me
       compress_me
+
+      write_build_summary
     end
 
     def write_json_manifest
       File.open(json_manifest_path, "w") do |f|
         f.write(FFI_Yajl::Encoder.encode(built_manifest.to_hash, pretty: true))
+      end
+    end
+
+    def write_build_summary
+      FileUtils.mkdir_p(Config.package_dir)
+      out_path = "#{Config.package_dir}/build-summary.json"
+      File.open(out_path, "w") do |f|
+        f.write(FFI_Yajl::Encoder.encode(build_summary.to_hash, pretty: true))
       end
     end
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -103,6 +103,8 @@ module Omnibus
       @project  = project
       @manifest = manifest
 
+      @build_summary = {"cached" => false, "build_duration" => 0}
+
       # Overrides
       @overrides = NULL
     end
@@ -1271,6 +1273,7 @@ module Omnibus
           project.dirty!(self)
         elsif git_cache.restore
           log.info(log_key) { "Restored from cache" }
+          @build_summary["cached"] = true
         else
           log.info(log_key) { "Could not restore from cache" }
           execute_build(build_wrappers)
@@ -1335,6 +1338,14 @@ module Omnibus
 
         digest.hexdigest
       end
+    end
+
+    def store_build_duration(duration)
+      @build_summary['build_duration'] = duration
+    end
+
+    def build_summary
+      @build_summary
     end
 
     private

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -103,7 +103,7 @@ module Omnibus
       @project  = project
       @manifest = manifest
 
-      @build_summary = {"cached" => false, "build_duration" => 0}
+      @build_summary = { "cached" => false, "build_duration" => 0 }
 
       # Overrides
       @overrides = NULL


### PR DESCRIPTION
This will allow us to have a better observability on our build & package durations, as we currently don't have a way (other than manually reading all logs) to know what takes most of our build times