### PR TITLE
Restore failing behavior when a command fails

### DIFF
--- a/lib/omnibus/instrumentation.rb
+++ b/lib/omnibus/instrumentation.rb
@@ -24,7 +24,7 @@ module Omnibus
     ensure
       elapsed = Time.now - start
       log.info(log_key) { "#{label}: #{elapsed.to_f.round(4)}s" }
-      return elapsed
+      elapsed
     end
   end
 end


### PR DESCRIPTION
I had jobs "passing" the omnibus build on datadog-agent (like [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/447940523)) when I expected them to fail due to a specific command failing. Digging a bit deeper and trying things on a dummy project I narrowed down the behavior to starting to happen after #183.

Testing this one change on that local dummy project shows that it restores the original behavior of the build crashing with an exception when a command fails.

The reason is that `return` immediately exits the `measure` method, which doesn't let `ensure` _properly end_ and thus, the exception gets swallowed (e.g. see [this explanation](https://matthew.kerwin.net.au/blog/20110509_ruby_gotcha_1)). Note that `measure` is called for each command's `execute`, meaning the `return` there just jumps out of the `measure` block here:

https://github.com/DataDog/omnibus-ruby/blob/b596ce8bb6de9ded69153047e28a84ef51f668bd/lib/omnibus/builder.rb#L947-L955