### PR TITLE
[CI] Deprecate qa/skip-qa label

### DIFF
--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -74,7 +74,7 @@ jobs:
           commit-message: 'omnibus: bump OMNIBUS_RUBY_VERSION'
           title: '[omnibus][automated] Bump OMNIBUS_RUBY_VERSION'
           branch: 'automated/omnibus-ruby/${{ github.event.number }}'
-          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change,qa/skip-qa'
+          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change,qa/no-code-change'
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}
 

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -74,7 +74,7 @@ jobs:
           commit-message: 'omnibus: bump OMNIBUS_RUBY_VERSION'
           title: '[omnibus][automated] Bump OMNIBUS_RUBY_VERSION'
           branch: 'automated/omnibus-ruby/${{ github.event.number }}'
-          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change,qa/no-code-change'
+          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change'
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}
 


### PR DESCRIPTION
### Description

`qa/skip-qa` -> `qa/no-code-change` in the auto pr creation in the datadog-agent repo

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
