### PR TITLE
Rework build & packaging duration measurements

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -762,12 +762,11 @@ module Omnibus
         end
       end
 
-      build_time = measure("Build #{software.name}") do
+      measure("Build #{software.name}", lambda { |d| software.store_build_duration(d) }) do
         build_commands.each do |command|
           execute(command)
         end
       end
-      software.store_build_duration(build_time)
 
       log.info(log_key) { "Finished build" }
     end

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -762,7 +762,7 @@ module Omnibus
         end
       end
 
-      measure("Build #{software.name}", lambda { |d| software.store_build_duration(d) }) do
+      measure("Build #{software.name}", software.method(:store_build_duration)) do
         build_commands.each do |command|
           execute(command)
         end

--- a/lib/omnibus/instrumentation.rb
+++ b/lib/omnibus/instrumentation.rb
@@ -27,7 +27,6 @@ module Omnibus
       if duration_cb
         duration_cb.call(elapsed)
       end
-      elapsed
     end
   end
 end

--- a/lib/omnibus/instrumentation.rb
+++ b/lib/omnibus/instrumentation.rb
@@ -18,12 +18,15 @@ module Omnibus
   module Instrumentation
     include Logging
 
-    def measure(label, &block)
+    def measure(label, duration_cb = nil)
       start = Time.now
       yield
     ensure
       elapsed = Time.now - start
       log.info(log_key) { "#{label}: #{elapsed.to_f.round(4)}s" }
+      if duration_cb
+        duration_cb.call(elapsed)
+      end
       elapsed
     end
   end

--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -177,11 +177,11 @@ module Omnibus
     #   - setup
     #   - build
     #
-    def run!
+    def run!(duration_cb = nil)
       # Ensure the package directory exists
       create_directory(Config.package_dir)
 
-      measure("Packaging time") do
+      measure("Packaging time", duration_cb) do
         # Run the setup and build sequences
         instance_eval(&self.class.setup) if self.class.setup
         instance_eval(&self.class.build) if self.class.build

--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -177,11 +177,11 @@ module Omnibus
     #   - setup
     #   - build
     #
-    def run!(duration_cb = nil)
+    def run!
       # Ensure the package directory exists
       create_directory(Config.package_dir)
 
-      measure("Packaging time", duration_cb) do
+      measure("Packaging time", ->(duration) { project.store_package_duration(id, duration) }) do
         # Run the setup and build sequences
         instance_eval(&self.class.setup) if self.class.setup
         instance_eval(&self.class.build) if self.class.build

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1446,7 +1446,7 @@ module Omnibus
       write_text_manifest
       HealthCheck.run!(self)
 
-      Stripper.run!(self, lambda { |d| @strip_duration = d }) if strip_build
+      Stripper.run!(self) if strip_build
 
       # Remove any package this project extends, after the health check ran
       extended_packages.each do |packages, _|
@@ -1464,6 +1464,14 @@ module Omnibus
       File.open(json_manifest_path, "w") do |f|
         f.write(FFI_Yajl::Encoder.encode(built_manifest.to_hash, pretty: true))
       end
+    end
+
+    def store_strip_duration(duration)
+      @strip_duration = duration
+    end
+
+    def store_package_duration(packager, duration)
+      @package_summary[packager] = duration
     end
 
     def write_build_summary
@@ -1516,7 +1524,7 @@ module Omnibus
           next
         end
         # Run the actual packager
-        packager.run!(lambda { |d| @package_summary[packager.id] = d })
+        packager.run!
 
         # Copy the generated package and metadata back into the workspace
         package_path = File.join(Config.package_dir, packager.package_name)

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1446,7 +1446,7 @@ module Omnibus
       write_text_manifest
       HealthCheck.run!(self)
 
-      @strip_duration = Stripper.run!(self) if strip_build
+      Stripper.run!(self, lambda { |d| @strip_duration = d }) if strip_build
 
       # Remove any package this project extends, after the health check ran
       extended_packages.each do |packages, _|
@@ -1516,7 +1516,7 @@ module Omnibus
           next
         end
         # Run the actual packager
-        @package_summary[packager.id] = packager.run!
+        packager.run!(lambda { |d| @package_summary[packager.id] = d })
 
         # Copy the generated package and metadata back into the workspace
         package_path = File.join(Config.package_dir, packager.package_name)

--- a/lib/omnibus/stripper.rb
+++ b/lib/omnibus/stripper.rb
@@ -9,8 +9,8 @@ module Omnibus
 
     class << self
       # @see (stripper#new)
-      def run!(project)
-        new(project).run!
+      def run!(project, duration_cb = nil)
+        new(project).run!(duration_cb)
       end
     end
 
@@ -40,8 +40,8 @@ module Omnibus
     # @return [true]
     #   if the checks pass
     #
-    def run!
-      measure("Stripping time") do
+    def run!(duration_cb = nil)
+      measure("Stripping time", duration_cb) do
         log.info(log_key) { "Running strip on #{project.name}" }
         # TODO: properly address missing platforms / linux
         case Ohai["platform"]

--- a/lib/omnibus/stripper.rb
+++ b/lib/omnibus/stripper.rb
@@ -9,8 +9,8 @@ module Omnibus
 
     class << self
       # @see (stripper#new)
-      def run!(project, duration_cb = nil)
-        new(project).run!(duration_cb)
+      def run!(project)
+        new(project).run!
       end
     end
 
@@ -40,8 +40,8 @@ module Omnibus
     # @return [true]
     #   if the checks pass
     #
-    def run!(duration_cb = nil)
-      measure("Stripping time", duration_cb) do
+    def run!
+      measure("Stripping time", project.method(:store_strip_duration)) do
         log.info(log_key) { "Running strip on #{project.name}" }
         # TODO: properly address missing platforms / linux
         case Ohai["platform"]


### PR DESCRIPTION
This provides a way to use duration computed by `measure` and generate a report with those, but without breaking failure detection this time