### PR TITLE
Replace our OCI packager with an XZ packager

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -31,6 +31,7 @@ module Omnibus
     autoload :IPS,      "omnibus/packagers/ips"
     autoload :RPM,      "omnibus/packagers/rpm"
     autoload :ZIP,      "omnibus/packagers/zip"
+    autoload :XZ,       "omnibus/packagers/xz"
 
     #
     # The list of Ohai platform families mapped to the respective packager
@@ -39,10 +40,10 @@ module Omnibus
     # @return [Hash<String, Class>]
     #
     PLATFORM_PACKAGER_MAP = {
-      "debian" => [DEB, OCIRU],
-      "fedora" => [RPM, OCIRU],
-      "suse" => [RPM, OCIRU],
-      "rhel" => [RPM, OCIRU],
+      "debian" => [DEB, XZ],
+      "fedora" => [RPM, XZ],
+      "suse" => [RPM, XZ],
+      "rhel" => [RPM, XZ],
       "wrlinux" => RPM,
       "aix" => BFF,
       "solaris" => Solaris,

--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -27,15 +27,14 @@ module Omnibus
 
     build do
       out_file = windows_safe_path(Config.package_dir, archive_name)
-      log.info(log_key) { "Outputing xz package to #{out_file}" }
       out_source_path = "#{windows_safe_path(project.install_dir)}/*"
+      compress_env = { "XZ_OPT" => "-T#{compression_threads} -#{compression_level}" }
       cmd = <<-EOH.split.join(" ").squeeze(" ").strip
         tar -cJf
         #{out_file}
         #{out_source_path}
       EOH
-      log.info(log_key) { "Running #{cmd}" }
-      shellout!(cmd)
+      shellout!(cmd, environment: compress_env)
     end
 
     def debug_build?
@@ -71,5 +70,31 @@ module Omnibus
       end
     end
     expose :safe_architecture
+
+    def compression_threads(val = nil)
+      if val.nil?
+        @compression_threads || 1
+      else
+        unless val > 0 && val < 32
+          raise InvalidValue.new(:compression_threads, 'be a stricly positive and lower than 32 Integer')
+        end
+
+        @compression_threads = val
+      end
+    end
+    expose :compression_threads
+
+    def compression_level(val = nil)
+      if val.nil?
+        @compression_level || 6
+      else
+        unless val >= 0 && val <= 9
+          raise InvalidValue.new(:compression_level, 'be an Integer between 0 and 9 included')
+        end
+
+        @compression_level = val
+      end
+    end
+    expose :compression_level
   end
 end

--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -63,13 +63,16 @@ module Omnibus
     #   the architecture
     #
     def safe_architecture(val = NULL)
-      if null?(val)
-        @safe_architecture ||= Ohai["kernel"]["machine"]
-      else
-        @safe_architecture = val
-      end
+      val = shellout!("uname --processor").stdout.strip
+
+      val = case val
+            when "x86_64", "x64", "amd64" then "amd64"
+            when "arm64", "aarch64" then "arm64"
+            when "armv7l" then "arm"
+            else raise ArgumentError, "Unknown architecture '#{val}'"
+            end
+      val
     end
-    expose :safe_architecture
 
     def compression_threads(val = nil)
       if val.nil?

--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -1,0 +1,75 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "pathname"
+require "omnibus/packagers/windows_base"
+require "fileutils"
+
+module Omnibus
+  class Packager::XZ < Packager::Base
+    id :xz
+
+    setup do
+    end
+
+    build do
+      out_file = windows_safe_path(Config.package_dir, archive_name)
+      log.info(log_key) { "Outputing xz package to #{out_file}" }
+      out_source_path = "#{windows_safe_path(project.install_dir)}/*"
+      cmd = <<-EOH.split.join(" ").squeeze(" ").strip
+        tar -cJf
+        #{out_file}
+        #{out_source_path}
+      EOH
+      log.info(log_key) { "Running #{cmd}" }
+      shellout!(cmd)
+    end
+
+    def debug_build?
+      false
+    end
+
+    # @see Base#package_name
+    def package_name
+      archive_name
+    end
+
+    def archive_name
+      "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar.xz"
+    end
+
+    #
+    # Set or return the architecture to set in the DEB control file
+    #
+    # @example
+    #   safe_architecture 'all'
+    #
+    # @param [String] val
+    #   A valid architecture for DEB control file
+    #
+    # @return [String]
+    #   the architecture
+    #
+    def safe_architecture(val = NULL)
+      if null?(val)
+        @safe_architecture ||= Ohai["kernel"]["machine"]
+      else
+        @safe_architecture = val
+      end
+    end
+    expose :safe_architecture
+  end
+end


### PR DESCRIPTION
OCI packaging is now handled by a dedicated tool, which we will invoke from our CI.

It will be fed with the resulting binaries which we can now package as XZ, as we don't need a complex packaging here, such as deb or rpm.