### PR TITLE
project: allow install dir not to be cleared

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1422,7 +1422,9 @@ module Omnibus
     end
 
     def build
-      FileUtils.rm_rf(install_dir)
+      if @clear_install_dir
+        FileUtils.rm_rf(install_dir)
+      end
       FileUtils.mkdir_p(install_dir)
 
       packager = packagers_for_system[0]
@@ -1614,6 +1616,19 @@ module Omnibus
         digest.hexdigest
       end
     end
+
+    def clear_install_dir(val = nil)
+      if val.nil?
+        if @clear_install_dir.nil?
+          true
+        else
+          @clear_install_dir
+        end
+      else
+        @clear_install_dir = val
+      end
+    end
+    expose :clear_install_dir
 
     #
     # @!endgroup


### PR DESCRIPTION
This is needed to be able to split build & packaging.
The build job provides the `install_dir` as an artifact, which the package job will convert to a `.deb` or other package, however omnibus currently wipes the install_dir obtained from the build job, which leads to the creation of an empty package