### PR TITLE
don't populate the cache for sofware marked as always_build

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1426,7 +1426,7 @@ module Omnibus
       builder.build
       build_wrappers.each { |wrapper| wrapper.execute_post_build(self) }
 
-      if Config.use_git_caching
+      if Config.use_git_caching && !always_build
         git_cache.incremental
         log.info(log_key) { "Dirtied the cache" }
       end


### PR DESCRIPTION
We don't want to populate the cache with software that will always be built, as it needlessly requires us to recreate a bundle and upload it for absolutely no gain