### PR TITLE
[rpm] disable creating build-id links

### DIFF
--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -15,6 +15,9 @@
 %define _binary_payload w<%= compression_level %>.<%= compression_algo %>
 <% end %>
 
+# Disable creation of build-id links
+%define _build_id_links none
+
 # Metadata
 Name: <%= name %>
 Version: <%= version %>


### PR DESCRIPTION
### Description

[AGENT-11471](https://datadoghq.atlassian.net/browse/AGENT-11471): disable creating build-id links for RPM packages to avoid creating file conflicts with other packages on RHEL8.

Relateds:
- https://github.com/chef/omnibus/pull/1050
- https://gitlab.com/gitlab-org/omnibus/-/merge_requests/39


[AGENT-11471]: https://datadoghq.atlassian.net/browse/AGENT-11471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ