### PR TITLE
xz: allow generating a debug archive

### DIFF
--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -41,7 +41,7 @@ module Omnibus
         cmd = <<-EOH.split.join(" ").squeeze(" ").strip
           tar -cJf
           #{out_file}
-          #{debug_package_paths.map{ |dir| File.join(install_dir, dir) }.join(' ')}
+          #{debug_package_paths.map { |dir| File.join(install_dir, dir) }.join(' ')}
         EOH
         shellout!(cmd, environment: compress_env)
       end

--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -26,7 +26,7 @@ module Omnibus
     end
 
     build do
-      out_file = windows_safe_path(Config.package_dir, archive_name)
+      out_file = windows_safe_path(Config.package_dir, package_name)
       input_paths = ["#{windows_safe_path(project.install_dir)}/*"] + project.extra_package_files
       compress_env = { "XZ_OPT" => "-T#{compression_threads} -#{compression_level}" }
       cmd = <<-EOH.split.join(" ").squeeze(" ").strip
@@ -37,7 +37,7 @@ module Omnibus
       shellout!(cmd, environment: compress_env)
 
       if debug_build?
-        out_file = windows_safe_path(Config.package_dir, archive_name(true))
+        out_file = windows_safe_path(Config.package_dir, package_name(true))
         cmd = <<-EOH.split.join(" ").squeeze(" ").strip
           tar -cJf
           #{out_file}
@@ -48,11 +48,7 @@ module Omnibus
     end
 
     # @see Base#package_name
-    def package_name
-      archive_name
-    end
-
-    def archive_name(debug = false)
+    def package_name(debug = false)
       "#{project.package_name}#{debug ? "-dbg" : ""}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar.xz"
     end
 

--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -35,10 +35,16 @@ module Omnibus
         #{input_paths.join(" ")}
       EOH
       shellout!(cmd, environment: compress_env)
-    end
 
-    def debug_build?
-      false
+      if debug_build?
+        out_file = windows_safe_path(Config.package_dir, archive_name(true))
+        cmd = <<-EOH.split.join(" ").squeeze(" ").strip
+          tar -cJf
+          #{out_file}
+          #{debug_package_paths.map{ |dir| File.join(install_dir, dir) }.join(' ')}
+        EOH
+        shellout!(cmd, environment: compress_env)
+      end
     end
 
     # @see Base#package_name
@@ -46,8 +52,8 @@ module Omnibus
       archive_name
     end
 
-    def archive_name
-      "#{project.package_name}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar.xz"
+    def archive_name(debug = false)
+      "#{project.package_name}#{debug ? "-dbg" : ""}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar.xz"
     end
 
     #


### PR DESCRIPTION
### Description

This allows us to create an intermediate artifact for debug symbols as well. In the context of splitting build and packaging, we can now build an agent, strip the resulting binaries once, and package those as debug symbols during the packaging stage.

This way we can pay for stripping only once, and don't have to ship unstripped binaries as part of the intermediate artifacts.
