### PR TITLE
Allow disabling healthcheck

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -81,7 +81,7 @@ module Omnibus
       @filepath = filepath
       @manifest = manifest
       @package_summary = {}
-      @disable_healthcheck = false
+      @skip_healthcheck = false
     end
 
     #
@@ -1445,7 +1445,7 @@ module Omnibus
 
       write_json_manifest
       write_text_manifest
-      unless @disable_healthcheck
+      unless @skip_healthcheck
         HealthCheck.run!(self)
       end
 
@@ -1618,14 +1618,14 @@ module Omnibus
       end
     end
 
-    def disable_healthcheck(val)
+    def skip_healthcheck(val)
       if val.nil?
-        @disable_healthcheck
+        @skip_healthcheck
       else
-        @disable_healthcheck = val
+        @skip_healthcheck = val
       end
     end
-    expose :disable_healthcheck
+    expose :skip_healthcheck
     #
     # @!endgroup
     # --------------------------------------------------

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -81,6 +81,7 @@ module Omnibus
       @filepath = filepath
       @manifest = manifest
       @package_summary = {}
+      @disable_healthcheck = false
     end
 
     #
@@ -1444,7 +1445,9 @@ module Omnibus
 
       write_json_manifest
       write_text_manifest
-      HealthCheck.run!(self)
+      unless @disable_healthcheck
+        HealthCheck.run!(self)
+      end
 
       Stripper.run!(self) if strip_build
 
@@ -1615,6 +1618,14 @@ module Omnibus
       end
     end
 
+    def disable_healthcheck(val)
+      if val.nil?
+        @disable_healthcheck
+      else
+        @disable_healthcheck = val
+      end
+    end
+    expose :disable_healthcheck
     #
     # @!endgroup
     # --------------------------------------------------


### PR DESCRIPTION
### Description

Our builds rely on some files being excluded from the healthcheck, which is done in our various build recipes. In order for the packaging not to fail, we need to disable the healthcheck during this stage.
It is still performed, once, during the build stage, meaning the intermediate artifacts have been checked already when packaging.
