### PR TITLE
s3 license: compute a different software hash ourselves

### DIFF
--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -162,10 +162,6 @@ module Omnibus
           raise InsufficientSpecification.new(:version, software)
         end
 
-        unless software.hash
-          raise InsufficientSpecification.new(:hash, software)
-        end
-
         # We add a custom hash of the software recipe in the cache key. It's an accurate way
         # to know if a software definition changed, as it takes into account the
         # resolved version (ie. the git commit hash if the source is a git repository,

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -176,8 +176,10 @@ module Omnibus
         digest = Digest::SHA256.new
         # This assumes all our softwares have an associated recipe file, unlike what's
         # done by omnibus in software.shasum
-        software_hash = update_with_file_content(digest, software.filename)
-        "licenses/#{software.name}-#{software.version}-#{software_hash.hexdigest}/#{File.basename(license_file)}"
+        software_hash = update_with_file_content(digest, software.filepath)
+        key = "licenses/#{software.name}-#{software.version}-#{software_hash.hexdigest}/#{File.basename(license_file)}"
+        log.info(log_key) { "Using license key: #{key}"}
+        key
       end
 
       private

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -176,7 +176,7 @@ module Omnibus
         digest = Digest::SHA256.new
         # This assumes all our softwares have an associated recipe file, unlike what's
         # done by omnibus in software.shasum
-        software_hash = update_with_file_content(digest, software.filepath)
+        software_hash = update_with_file_contents(digest, software.filepath)
         key = "licenses/#{software.name}-#{software.version}-#{software_hash.hexdigest}/#{File.basename(license_file)}"
         log.info(log_key) { "Using license key: #{key}"}
         key

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -176,8 +176,8 @@ module Omnibus
         digest = Digest::SHA256.new
         # This assumes all our softwares have an associated recipe file, unlike what's
         # done by omnibus in software.shasum
-        software_hash = update_with_file_contents(digest, software.filepath)
-        key = "licenses/#{software.name}-#{software.version}-#{software_hash.hexdigest}/#{File.basename(license_file)}"
+        update_with_file_contents(digest, software.filepath)
+        key = "licenses/#{software.name}-#{software.version}-#{digest.hexdigest}/#{File.basename(license_file)}"
         log.info(log_key) { "Using license key: #{key}"}
         key
       end

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -167,8 +167,11 @@ module Omnibus
         # resolved version (ie. the git commit hash if the source is a git repository,
         # the hashsum of the downloaded file if the source is a remote file), the project,
         # and all build commands run in the software definition.
-        # We can't rely on the software.shasum directly as it includes the hash of all the other
-        # softwares it depends on, which causes the checksum to change way too often.
+        # We can't rely on the software.shasum directly: software.shasum includes
+        # project.shasum, which value depends on the install directory.
+        # As our OCI builds change their install directory for each pipeline by design,
+        # this would end up creating a new cache entry for every pipeline, ultimately
+        # heavily slowing down each cache lookup.
         digest = Digest::SHA256.new
         # This assumes all our softwares have an associated recipe file, unlike what's
         # done by omnibus in software.shasum

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -166,12 +166,18 @@ module Omnibus
           raise InsufficientSpecification.new(:hash, software)
         end
 
-        # We add Software#shasum in the cache key. It's an accurate way
+        # We add a custom hash of the software recipe in the cache key. It's an accurate way
         # to know if a software definition changed, as it takes into account the
         # resolved version (ie. the git commit hash if the source is a git repository,
         # the hashsum of the downloaded file if the source is a remote file), the project,
         # and all build commands run in the software definition.
-        "licenses/#{software.name}-#{software.version}-#{software.shasum}/#{File.basename(license_file)}"
+        # We can't rely on the software.shasum directly as it includes the hash of all the other
+        # softwares it depends on, which causes the checksum to change way too often.
+        digest = Digest::SHA256.new
+        # This assumes all our softwares have an associated recipe file, unlike what's
+        # done by omnibus in software.shasum
+        software_hash = update_with_file_content(digest, software.filename)
+        "licenses/#{software.name}-#{software.version}-#{software_hash.hexdigest}/#{File.basename(license_file)}"
       end
 
       private

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -163,10 +163,8 @@ module Omnibus
         end
 
         # We add a custom hash of the software recipe in the cache key. It's an accurate way
-        # to know if a software definition changed, as it takes into account the
-        # resolved version (ie. the git commit hash if the source is a git repository,
-        # the hashsum of the downloaded file if the source is a remote file), the project,
-        # and all build commands run in the software definition.
+        # to know if a software definition changed, as it takes into account recipe file
+        # which contains the software version and all the commands used to build it
         # We can't rely on the software.shasum directly: software.shasum includes
         # project.shasum, which value depends on the install directory.
         # As our OCI builds change their install directory for each pipeline by design,

--- a/lib/omnibus/s3_license_cache.rb
+++ b/lib/omnibus/s3_license_cache.rb
@@ -173,9 +173,7 @@ module Omnibus
         # This assumes all our softwares have an associated recipe file, unlike what's
         # done by omnibus in software.shasum
         update_with_file_contents(digest, software.filepath)
-        key = "licenses/#{software.name}-#{software.version}-#{digest.hexdigest}/#{File.basename(license_file)}"
-        log.info(log_key) { "Using license key: #{key}"}
-        key
+        "licenses/#{software.name}-#{software.version}-#{digest.hexdigest}/#{File.basename(license_file)}"
       end
 
       private


### PR DESCRIPTION
Use a custom hash to cache software licenses.
`software.shasum` is impacted by all the dependencies of the software, which causes the key to change way too often, and in turn slows down the builds drastically while omnibus checks the available keys in the cache