### PR TITLE
Catch up to upstream on fixes for DMG creation

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -36,6 +36,7 @@ module Omnibus
     build do
       create_writable_dmg
       attach_dmg
+      copy_assets_to_dmg
       # Give some time to the system so attached dmg shows up in Finder
       sleep 5
       set_volume_icon
@@ -138,11 +139,9 @@ module Omnibus
 
       shellout! <<-EOH.gsub(/^ {8}/, "")
         hdiutil create \\
-          -srcfolder "#{resources_dir}" \\
           -volname "#{volume_name}" \\
           -fs HFS+ \\
           -fsargs "-c c=64,a=16,e=16" \\
-          -format UDRW \\
           -size 512000k \\
           "#{writable_dmg}"
       EOH
@@ -167,6 +166,17 @@ module Omnibus
         EOH
 
         cmd.stdout.strip
+      end
+    end
+
+    #
+    # Copy assets to dmg
+    #
+    def copy_assets_to_dmg
+      log.info(log_key) { "Copying assets into dmg" }
+
+      FileSyncer.glob("#{resources_dir}/*").each do |file|
+        FileUtils.cp_r(file, "/Volumes/#{volume_name}")
       end
     end
 

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -259,8 +259,8 @@ module Omnibus
           sync
           hdiutil unmount "#{@device}"
           # Give some time to the system so unmount dmg
-          ATTEMPTS=0
-          until [ $ATTEMPTS -eq 5 ] || hdiutil detach "#{@device}"; do
+          ATTEMPTS=1
+          until [ $ATTEMPTS -eq 6 ] || hdiutil detach "#{@device}"; do
             sleep 10
             echo Attempt number $(( ATTEMPTS++ ))
           done

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -259,8 +259,11 @@ module Omnibus
           sync
           hdiutil unmount "#{@device}"
           # Give some time to the system so unmount dmg
-          sleep 5
-          hdiutil detach "#{@device}" &&  \
+          ATTEMPTS=0
+          until [ $ATTEMPTS -eq 5 ] || hdiutil detach "#{@device}"; do
+            sleep 10
+            echo Attempt number $(( ATTEMPTS++ ))
+          done
           hdiutil convert \\
             "#{writable_dmg}" \\
             -format UDZO \\

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -144,7 +144,8 @@ module Omnibus
           -fs HFS+ \\
           -fsargs "-c c=64,a=16,e=16" \\
           -size 512000k \\
-          "#{writable_dmg}"
+          "#{writable_dmg}" \\
+          -puppetstrings
       EOH
     end
 
@@ -160,6 +161,7 @@ module Omnibus
 
         cmd = shellout! <<-EOH.gsub(/^ {10}/, "")
           hdiutil attach \\
+            -puppetstrings \\
             -readwrite \\
             -noverify \\
             -noautoopen \\
@@ -260,7 +262,8 @@ module Omnibus
             -format UDZO \\
             -imagekey \\
             zlib-level=9 \\
-            -o "#{package_path}"
+            -o "#{package_path}" \\
+            -puppetstrings
         EOH
       end
     end

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -230,7 +230,9 @@ module Omnibus
     end
 
     #
-    # Compress the dmg using hdiutil and zlib.
+    # Compress the dmg using hdiutil and zlib. zlib offers better compression
+    # levels than bzip2 (10.4+) or LZFSE (10.11+), but takes longer to compress.
+    # We're willing to trade slightly longer build times for smaller package sizes.
     #
     # @return [void]
     #

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -118,7 +118,7 @@ module Omnibus
     def clean_disks
       log.info(log_key) { "Cleaning previously mounted disks" }
 
-      existing_disks = shellout!("mount | grep /Volumes/#{volume_name} | awk '{print $1}'")
+      existing_disks = shellout!("mount | grep \"/Volumes/#{volume_name}\" | awk '{print $1}'")
       existing_disks.stdout.lines.each do |existing_disk|
         existing_disk.chomp!
 
@@ -239,7 +239,7 @@ module Omnibus
 
       Dir.chdir(staging_dir) do
         shellout! <<-EOH.gsub(/^ {10}/, "")
-          chmod -Rf go-w /Volumes/#{volume_name}
+          chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
           hdiutil detach "#{@device}"
           hdiutil convert \\

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -257,6 +257,9 @@ module Omnibus
         shellout! <<-EOH.gsub(/^ {10}/, "")
           chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
+          hdiutil unmount "#{@device}"
+          # Give some time to the system so unmount dmg
+          sleep 5
           hdiutil detach "#{@device}" &&  \
           hdiutil convert \\
             "#{writable_dmg}" \\

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -43,6 +43,7 @@ module Omnibus
       prettify_dmg
       compress_dmg
       set_dmg_icon
+      remove_writable_dmg
     end
 
     #
@@ -260,6 +261,20 @@ module Omnibus
             -imagekey \\
             zlib-level=9 \\
             -o "#{package_path}"
+        EOH
+      end
+    end
+
+    #
+    # Remove writable dmg.
+    #
+    # @return [void]
+    #
+    def remove_writable_dmg
+      log.info(log_key) { "Removing writable dmg" }
+
+      Dir.chdir(staging_dir) do
+        shellout! <<-EOH.gsub(/^ {10}/, "")
           rm -rf "#{writable_dmg}"
         EOH
       end

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -257,7 +257,7 @@ module Omnibus
         shellout! <<-EOH.gsub(/^ {10}/, "")
           chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
-          hdiutil detach "#{@device}"
+          hdiutil detach "#{@device}" &&  \
           hdiutil convert \\
             "#{writable_dmg}" \\
             -format UDZO \\

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -43,6 +43,7 @@ module Omnibus
       prettify_dmg
       compress_dmg
       set_dmg_icon
+      verify_dmg
       remove_writable_dmg
     end
 
@@ -263,6 +264,23 @@ module Omnibus
             -imagekey \\
             zlib-level=9 \\
             -o "#{package_path}" \\
+            -puppetstrings
+        EOH
+      end
+    end
+
+    #
+    # Verify checksum on created dmg.
+    #
+    # @return [void]
+    #
+    def verify_dmg
+      log.info(log_key) { "Verifying dmg" }
+
+      Dir.chdir(staging_dir) do
+        shellout! <<-EOH.gsub(/^ {10}/, "")
+          hdiutil verify \\
+            "#{package_path}" \\
             -puppetstrings
         EOH
       end

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -245,6 +245,24 @@ module Omnibus
       end
     end
 
+    describe "#verify_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.verify_dmg }
+        expect(output).to include("Verifying dmg")
+      end
+
+      it "runs the command" do
+        expect(subject).to receive(:shellout!)
+          .with <<-EOH.gsub(/^ {12}/, "")
+            hdiutil verify \\
+              "#{package_dir}/project-1.2.3-2.dmg" \\
+              -puppetstrings
+          EOH
+
+        subject.verify_dmg
+      end
+    end
+
     describe "#remove_writable_dmg" do
       it "logs a message" do
         output = capture_logging { subject.remove_writable_dmg }

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -236,14 +236,29 @@ module Omnibus
               -imagekey \\
               zlib-level=9 \\
               -o "#{package_dir}/project-1.2.3-2.dmg"
-            rm -rf "#{staging_dir}/project-writable.dmg"
           EOH
 
         subject.compress_dmg
       end
     end
 
-    describe '#set_dmg_icon' do
+    describe "#remove_writable_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.remove_writable_dmg }
+        expect(output).to include("Removing writable dmg")
+      end
+
+      it "runs the command" do
+        expect(subject).to receive(:shellout!)
+          .with <<-EOH.gsub(/^ {12}/, "")
+            rm -rf "#{staging_dir}/project-writable.dmg"
+          EOH
+
+        subject.remove_writable_dmg
+      end
+    end
+
+    describe "#set_dmg_icon" do
       it "logs a message" do
         output = capture_logging { subject.set_dmg_icon }
         expect(output).to include("Setting dmg icon")

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -233,8 +233,8 @@ module Omnibus
             sync
             hdiutil unmount "#{device}"
             # Give some time to the system so unmount dmg
-            ATTEMPTS=0
-            until [ $ATTEMPTS -eq 5 ] || hdiutil detach "/dev/sda1"; do
+            ATTEMPTS=1
+            until [ $ATTEMPTS -eq 6 ] || hdiutil detach "/dev/sda1"; do
               sleep 10
               echo Attempt number $(( ATTEMPTS++ ))
             done

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -231,7 +231,7 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             chmod -Rf go-w "/Volumes/Project One"
             sync
-            hdiutil detach "#{device}"
+            hdiutil detach "#{device}" &&\
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\
               -format UDZO \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -231,6 +231,9 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             chmod -Rf go-w "/Volumes/Project One"
             sync
+            hdiutil unmount "#{device}"
+            # Give some time to the system so unmount dmg
+            sleep 5
             hdiutil detach "#{device}" &&\
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -233,8 +233,11 @@ module Omnibus
             sync
             hdiutil unmount "#{device}"
             # Give some time to the system so unmount dmg
-            sleep 5
-            hdiutil detach "#{device}" &&\
+            ATTEMPTS=0
+            until [ $ATTEMPTS -eq 5 ] || hdiutil detach "/dev/sda1"; do
+              sleep 10
+              echo Attempt number $(( ATTEMPTS++ ))
+            done
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\
               -format UDZO \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -86,11 +86,9 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil create \\
-              -srcfolder "#{staging_dir}/Resources" \\
               -volname "Project One" \\
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
-              -format UDRW \\
               -size 512000k \\
               "#{staging_dir}/project-writable.dmg"
           EOH
@@ -130,7 +128,14 @@ module Omnibus
       end
     end
 
-    describe '#set_volume_icon' do
+    describe "#copy_assets_to_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.copy_assets_to_dmg }
+        expect(output).to include("Copying assets into dmg")
+      end
+    end
+
+    describe "#set_volume_icon" do
       it "logs a message" do
         output = capture_logging { subject.set_volume_icon }
         expect(output).to include("Setting volume icon")

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -5,6 +5,7 @@ module Omnibus
     let(:project) do
       Project.new.tap do |project|
         project.name("project")
+        project.friendly_name("Project One")
         project.homepage("https://example.com")
         project.install_dir("/opt/project")
         project.build_version("1.2.3")
@@ -86,7 +87,7 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil create \\
               -srcfolder "#{staging_dir}/Resources" \\
-              -volname "Project" \\
+              -volname "Project One" \\
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
               -format UDRW \\
@@ -155,10 +156,10 @@ module Omnibus
             iconutil -c icns tmp.iconset
 
             # Copy it over
-            cp tmp.icns "/Volumes/Project/.VolumeIcon.icns"
+            cp tmp.icns "/Volumes/Project One/.VolumeIcon.icns"
 
             # Source the icon
-            SetFile -a C "/Volumes/Project"
+            SetFile -a C "/Volumes/Project One"
           EOH
 
         subject.set_volume_icon
@@ -181,7 +182,7 @@ module Omnibus
         contents = File.read("#{staging_dir}/create_dmg.osascript")
 
         expect(contents).to include('tell application "Finder"')
-        expect(contents).to include('  tell disk "Project"')
+        expect(contents).to include('  tell disk "Project One"')
         expect(contents).to include("    open")
         expect(contents).to include("    set current view of container window to icon view")
         expect(contents).to include("    set toolbar visible of container window to false")
@@ -221,7 +222,7 @@ module Omnibus
 
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
-            chmod -Rf go-w /Volumes/Project
+            chmod -Rf go-w "/Volumes/Project One"
             sync
             hdiutil detach "#{device}"
             hdiutil convert \\
@@ -291,8 +292,7 @@ module Omnibus
 
     describe '#volume_name' do
       it "is the project friendly_name" do
-        project.friendly_name("Friendly Bacon Bits")
-        expect(subject.volume_name).to eq("Friendly Bacon Bits")
+        expect(subject.volume_name).to eq("Project One")
       end
     end
   end

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -90,7 +90,8 @@ module Omnibus
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
               -size 512000k \\
-              "#{staging_dir}/project-writable.dmg"
+              "#{staging_dir}/project-writable.dmg" \\
+              -puppetstrings
           EOH
 
         subject.create_writable_dmg
@@ -114,6 +115,7 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil attach \\
+              -puppetstrings \\
               -readwrite \\
               -noverify \\
               -noautoopen \\
@@ -235,7 +237,8 @@ module Omnibus
               -format UDZO \\
               -imagekey \\
               zlib-level=9 \\
-              -o "#{package_dir}/project-1.2.3-2.dmg"
+              -o "#{package_dir}/project-1.2.3-2.dmg" \\
+              -puppetstrings
           EOH
 
         subject.compress_dmg


### PR DESCRIPTION
Cherry picked commits from https://github.com/chef/omnibus/commits/main/lib/omnibus/compressors/dmg.rb so that we apply a string of fixes that upstream has been applying.

The context for this is some recurring failures to have the DMG be correctly created at the end of the Omnibus build (it failed silently producing an empty dmg file).

I'm not in a good position to assess how these may correct the errors that we're seeing, but at the very least the addition of retries on the `compress_dmg` method should be helping, and the verification of the file should cause an error to be triggered closer to the failure (instead of on the notarization step).

Test Run: https://github.com/DataDog/datadog-agent-macos-build/actions/runs/9498196427/job/26176389431
