### PR TITLE
Custom installation path support

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -553,7 +553,7 @@ module Omnibus
           #         name /opt/datadog-agent/embedded/lib (offset 12)
           yield_shellout_results("otool -l #{current_library} | grep LC_RPATH -A2 | grep path | awk '{ print $2 }'") do |rpath|
             # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
-            # If @rpath contains @loader_path we're replacing it with it's actual loader_path
+            # We also resolve possible `@loader_path` references
             possible_paths << linked.sub("@rpath", rpath.chop).sub("@loader_path", loader_path)
           end
         # Do the linker's work of replacing @loader_path by the directory the library that's using the dependency is in

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -135,8 +135,6 @@ module Omnibus
       /libSystem\.B\.dylib/,
       # Symlink of the previous one
       /libgcc_s\.1\.dylib/,
-      /libz\.1\.dylib/,
-      /libdatadog-agent-rtloader\.1\.dylib/,
       /CoreFoundation/,
       /CoreServices/,
       /Tcl$/,
@@ -535,6 +533,7 @@ module Omnibus
         rpath_regexp = Regexp.new("@rpath")
         loader_path_regexp = Regexp.new("@loader_path")
         install_dir_regexp = Regexp.new(project.install_dir)
+        loader_path = File.dirname(current_library)
 
         # Do the linker's work of replacing @rpath with the rpaths defined by the library
         if linked =~ rpath_regexp
@@ -554,11 +553,11 @@ module Omnibus
           #         name /opt/datadog-agent/embedded/lib (offset 12)
           yield_shellout_results("otool -l #{current_library} | grep LC_RPATH -A2 | grep path | awk '{ print $2 }'") do |rpath|
             # The rpath variable contains a \n (\r\n on Windows), so we remove it when including it in the complete path
-            possible_paths << linked.sub("@rpath", rpath.chop)
+            # If @rpath contains @loader_path we're replacing it with it's actual loader_path
+            possible_paths << linked.sub("@rpath", rpath.chop).sub("@loader_path", loader_path)
           end
         # Do the linker's work of replacing @loader_path by the directory the library that's using the dependency is in
         elsif linked =~ loader_path_regexp
-          loader_path = File.dirname(current_library)
           possible_paths = [linked.sub("@loader_path", loader_path)]
         else
           possible_paths = [linked]

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -136,6 +136,7 @@ module Omnibus
       # Symlink of the previous one
       /libgcc_s\.1\.dylib/,
       /libz\.1\.dylib/,
+      /libdatadog-agent-rtloader\.1\.dylib/,
       /CoreFoundation/,
       /CoreServices/,
       /Tcl$/,

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -135,6 +135,7 @@ module Omnibus
       /libSystem\.B\.dylib/,
       # Symlink of the previous one
       /libgcc_s\.1\.dylib/,
+      /libz\.1\.dylib/,
       /CoreFoundation/,
       /CoreServices/,
       /Tcl$/,

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -726,7 +726,7 @@ module Omnibus
           }
         when "mac_os_x", "macos"
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z,origin",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z origin",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "solaris2"
@@ -735,13 +735,13 @@ module Omnibus
               # this override is due to a bug in libtool documented here:
               # http://lists.gnu.org/archive/html/bug-libtool/2005-10/msg00004.html
               "CC" => "gcc -static-libgcc",
-              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
+              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include",
             }
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {
               "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
+              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           end
@@ -786,7 +786,7 @@ module Omnibus
           }
         else
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z,origin",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z origin",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -726,7 +726,7 @@ module Omnibus
           }
         when "mac_os_x", "macos"
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z,origin",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "solaris2"
@@ -735,13 +735,13 @@ module Omnibus
               # this override is due to a bug in libtool documented here:
               # http://lists.gnu.org/archive/html/bug-libtool/2005-10/msg00004.html
               "CC" => "gcc -static-libgcc",
-              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
+              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include",
             }
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {
               "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
+              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           end
@@ -786,7 +786,7 @@ module Omnibus
           }
         else
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z,origin",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -726,7 +726,7 @@ module Omnibus
           }
         when "mac_os_x", "macos"
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "solaris2"

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -726,7 +726,7 @@ module Omnibus
           }
         when "mac_os_x", "macos"
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z origin",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "solaris2"
@@ -735,13 +735,13 @@ module Omnibus
               # this override is due to a bug in libtool documented here:
               # http://lists.gnu.org/archive/html/bug-libtool/2005-10/msg00004.html
               "CC" => "gcc -static-libgcc",
-              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z origin",
+              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
               "CFLAGS" => "-I#{install_dir}/embedded/include",
             }
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {
               "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z origin",
+              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           end
@@ -786,7 +786,7 @@ module Omnibus
           }
         else
           {
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib,-z origin",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -741,7 +741,7 @@ module Omnibus
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {
               "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
+              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
               "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -741,7 +741,7 @@ module Omnibus
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {
               "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
+              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc,-z,origin",
               "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           end
@@ -786,6 +786,7 @@ module Omnibus
           }
         else
           {
+            # -z origin makes the rpath interpret the $ORIGIN variable as the binary path
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }


### PR DESCRIPTION
### Description

Allow omnibus to build an agent able to be ran from any path by adding the origin flag inside of linux `LDFLAGS` and adds two libraries inside of the healthcheck whitelist for macOS.
