### PR TITLE
Prepare for updated toolchains

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -241,9 +241,13 @@ module Omnibus
       cmake_cmd << "-DCMAKE_INSTALL_LIBDIR=#{libdir}" if libdir && libdir != ""
       rpath = options.delete(:rpath) || "#{prefix}/#{libdir}"
       cmake_cmd << "-DCMAKE_INSTALL_RPATH=#{rpath}" if rpath && rpath != ""
+
+      if ENV['DD_CMAKE_TOOLCHAIN']
+        cmake_cmd << "--toolchain #{ENV['DD_CMAKE_TOOLCHAIN']}"
+      end
+
       cmake_cmd.concat args
       cmake_cmd = cmake_cmd.join(" ").strip
-
       command(cmake_cmd, options)
 
       make("-j #{workers}", options)

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -798,11 +798,11 @@ module Omnibus
             DD_CMAKE_TOOLCHAIN: nil,
           }
           to_forward.each do |orig, forwarded|
-            if ENV[orig]
-              flags[forwarded] = ENV[orig] if forwarded
+            if ENV[orig.to_s]
+              flags[forwarded] = ENV[orig.to_s] if forwarded
               # Forward the toolchain env since some invoke tasks
               # rely on it down the line
-              flags[orig] = ENV[orig]
+              flags[orig.to_s] = ENV[orig.to_s]
             end
           end
           flags

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -797,7 +797,7 @@ module Omnibus
             "DD_CXX" => "CXX",
             "DD_CMAKE_TOOLCHAIN" => nil,
           }
-          to_forward.each do |orig,forwarded|
+          to_forward.each do |orig, forwarded|
             if ENV[orig]
               flags[forwarded] = ENV[orig] if forwarded
               # Forward the toolchain env since some invoke tasks

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -790,18 +790,20 @@ module Omnibus
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin  -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
-          if ENV["DD_CC"]
-            flags["CC"] = ENV["DD_CC"]
-            # Forward the toolchain env since some invoke tasks
-            # rely on it down the line
-            flags["DD_CC"] = ENV["DD_CC"]
-          end
-          if ENV["DD_CXX"]
-            flags["CXX"] = ENV["DD_CXX"]
-            flags["DD_CXX"] = ENV["DD_CXX"]
-          end
-          if ENV["DD_CMAKE_TOOLCHAIN"]
-            flags["DD_CMAKE_TOOLCHAIN"] = ENV["DD_CMAKE_TOOLCHAIN"]
+          # List of environment variables to forward and potentially map to an alternate name
+          # If the value is nil, the key will simply be forwarded from ENV to flags
+          to_forward = {
+            "DD_CC" => "CC",
+            "DD_CXX" => "CXX",
+            "DD_CMAKE_TOOLCHAIN" => nil,
+          }
+          to_forward.each do |orig,forwarded|
+            if ENV[orig]
+              flags[forwarded] = ENV[orig] if forwarded
+              # Forward the toolchain env since some invoke tasks
+              # rely on it down the line
+              flags[orig] = ENV[orig]
+            end
           end
           flags
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -785,11 +785,25 @@ module Omnibus
             "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O2 -fno-lto #{opt_flag}",
           }
         else
-          {
+          flags = {
             # -z origin makes the rpath interpret the $ORIGIN variable as the binary path
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin  -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
+          if ENV["DD_CC"]
+            flags["CC"] = ENV["DD_CC"]
+            # Forward the toolchain env since some invoke tasks
+            # rely on it down the line
+            flags["DD_CC"] = ENV["DD_CC"]
+          end
+          if ENV["DD_CXX"]
+            flags["CXX"] = ENV["DD_CXX"]
+            flags["DD_CXX"] = ENV["DD_CXX"]
+          end
+          if ENV["DD_CMAKE_TOOLCHAIN"]
+            flags["DD_CMAKE_TOOLCHAIN"] = ENV["DD_CMAKE_TOOLCHAIN"]
+          end
+          flags
         end
 
       # merge LD_RUN_PATH into the environment.  most unix distros will fall

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -787,7 +787,7 @@ module Omnibus
         else
           {
             # -z origin makes the rpath interpret the $ORIGIN variable as the binary path
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin  -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -787,15 +787,15 @@ module Omnibus
         else
           flags = {
             # -z origin makes the rpath interpret the $ORIGIN variable as the binary path
-            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin  -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
           # List of environment variables to forward and potentially map to an alternate name
           # If the value is nil, the key will simply be forwarded from ENV to flags
           to_forward = {
-            "DD_CC" => "CC",
-            "DD_CXX" => "CXX",
-            "DD_CMAKE_TOOLCHAIN" => nil,
+            DD_CC: "CC",
+            DD_CXX: "CXX",
+            DD_CMAKE_TOOLCHAIN: nil,
           }
           to_forward.each do |orig, forwarded|
             if ENV[orig]


### PR DESCRIPTION
This PR contains some preliminary work for https://github.com/DataDog/datadog-agent/pull/28262

It fixes implicit linking with our libraries dependencies, and allows us to chose a different compiler that the default `gcc`/`g++` without having to override the environment variable globally.