### PR TITLE
Hardcode pkg installation directory to /opt/datadog-agent

### DIFF
--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -191,7 +191,7 @@ module Omnibus
           --version "#{safe_version}" \\
           --scripts "#{scripts_dir}" \\
           --root "#{project.install_dir}" \\
-          --install-location "#{project.install_dir}" \\
+          --install-location "/opt/datadog-agent" \\
           "#{component_pkg}"
       EOH
 


### PR DESCRIPTION
### Description

Since we're able to build and package from anywhere on macOS the generated `.pkg` file is trying to install itself at the custom build location. For now we want to unblock macOS runner work by setting the installation directory to `/opt/datadog-agent`. We'll want to come back on this PR to allow to set the end installation path for linux and macOS on a variable.