### PR TITLE
fix --prefix value when using autoconf on windows

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -217,6 +217,10 @@ module Omnibus
       # Accept a prefix override if provided. Can be set to '' to suppress
       # this functionality.
       prefix = options.delete(:prefix) || "#{install_dir}/embedded"
+
+      if windows_target?
+        prefix.sub! "C:/", "/c/"
+      end
       configure_cmd << "--prefix=#{prefix}" if prefix && prefix != ""
 
       configure_cmd.concat args


### PR DESCRIPTION
This is needed when a `Makefile` target depends on a rule with an absolute path located in the prefix.

Since the prefix will contain a `:`, this causes syntax errors in the generated Makefiles
