### PR TITLE
Support an explicit target install location for macOS packages

### DIFF
--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -118,6 +118,29 @@ module Omnibus
     expose :signing_identity
 
     #
+    # Set or return the install location. If this value is provided,
+    # the created PKG will be configured to install at this location,
+    # defaulting to the project's install dir otherwise.
+    #
+    # @example
+    #   install_location "/opt/my-package"
+    #
+    # @param [String] val
+    #   the location override for where to install the packate
+    #
+    # @return [String]
+    #   the location where the package will be installed
+    #
+    def install_location(val = NULL)
+      if null?(val)
+        @install_location || project.install_dir
+      else
+        @install_location = val
+      end
+    end
+    expose :install_location
+
+    #
     # @!endgroup
     # --------------------------------------------------
 
@@ -191,7 +214,7 @@ module Omnibus
           --version "#{safe_version}" \\
           --scripts "#{scripts_dir}" \\
           --root "#{project.install_dir}" \\
-          --install-location "/opt/datadog-agent" \\
+          --install-location "#{install_location}" \\
           "#{component_pkg}"
       EOH
 


### PR DESCRIPTION
[BARX-591](https://datadoghq.atlassian.net/browse/BARX-591)

This adds an option to the `pkg` packager so that the install location can be overriden.

Tested manually through:
- https://github.com/DataDog/datadog-agent/pull/30894/commits/df97691f1287d00a15f3ba0a74a910f1f6de07fe
- https://github.com/DataDog/datadog-agent-macos-build/tree/alopez/test-custom-install-dir
- Resulting job: https://github.com/DataDog/datadog-agent-macos-build/actions/runs/11739296312/job/32703517279

Then used the artifact from that job and installed it on my machine, after which this demonstrates that it was installed in the expected target path (`/opt/datadog-agent`) rather than the one it was built on (`/opt/alt-path/datadog-agent`).

```
❯ /opt/datadog-agent/bin/agent/agent version
Agent 7.61.0-devel - Meta: git.111.df97691 - Commit: df97691f12 - Serialization version: v5.0.135 - Go version: go1.22.8
```


[BARX-591]: https://datadoghq.atlassian.net/browse/BARX-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ