### PR TITLE
configure: use the expected default value for windows prefix

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -209,7 +209,8 @@ module Omnibus
       # arrive at differently terrible wild ass guesses for what MSYSTEM=MINGW64
       # means. This can be anything from x86_64-pc-mingw64 to i686-pc-mingw32
       # which doesn't even make any sense...
-      if windows?
+      no_force_build = options.delete(:no_build_triplet) || false
+      if windows? && !no_force_build
         platform = windows_arch_i386? ? "i686-w64-mingw32" : "x86_64-w64-mingw32"
         configure_cmd << "--build=#{platform}"
       end

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -217,7 +217,7 @@ module Omnibus
 
       # Accept a prefix override if provided. Can be set to '' to suppress
       # this functionality.
-      default_prefix = unless windows? then "#{install_dir}/embedded" else python_3_embedded end
+      default_prefix = if !windows? then "#{install_dir}/embedded" else python_3_embedded end
       prefix = options.delete(:prefix) || default_prefix
       configure_cmd << "--prefix=#{prefix}" if prefix && prefix != ""
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -216,7 +216,8 @@ module Omnibus
 
       # Accept a prefix override if provided. Can be set to '' to suppress
       # this functionality.
-      prefix = options.delete(:prefix) || "#{install_dir}/embedded"
+      default_prefix = unless windows? then "#{install_dir}/embedded" else python_3_embedded end
+      prefix = options.delete(:prefix) || default_prefix
       configure_cmd << "--prefix=#{prefix}" if prefix && prefix != ""
 
       configure_cmd.concat args


### PR DESCRIPTION
* Use `embedded3` as the default install path on Windows
* Allow `configure` callers to skip `--build` parameter on windows (OpenSSL configure script doesn't accept that parameter)