### PR TITLE
Always ship source/source offers

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1292,7 +1292,7 @@ module Omnibus
           log.info(log_key) { "Restored from cache" }
           @build_summary["cached"] = true
           # Ensure we ship the source offer even when restoring from cache
-          fetcher.deploy
+          fetcher.clean
         else
           log.info(log_key) { "Could not restore from cache" }
           execute_build(build_wrappers)

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1291,6 +1291,8 @@ module Omnibus
         elsif git_cache.restore
           log.info(log_key) { "Restored from cache" }
           @build_summary["cached"] = true
+          # Ensure we ship the source offer even when restoring from cache
+          fetcher.deploy
         else
           log.info(log_key) { "Could not restore from cache" }
           execute_build(build_wrappers)


### PR DESCRIPTION
Calling `fetcher.clean` end up calling `fetcher.deploy` for all the sources we fetch. 
This doesn't impact the build part, sources are only extracted like they would if there was a cache miss.

https://datadoghq.atlassian.net/browse/BARX-773