### PR TITLE
[BARX-775] Clone directly to the right revision

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -151,8 +151,14 @@ module Omnibus
     # @return [void]
     #
     def git_clone
-      retry_block("git clone", [CommandTimeout, CommandFailed]) do
-        git("clone#{" --recursive" if clone_submodules?} #{source_url} .")
+      retry_block("custom git clone", [CommandTimeout, CommandFailed]) do
+        git("init")
+        git("remote add origin #{source_url}")
+        git("fetch origin #{resolved_version}")
+        git("checkout #{resolved_version}")
+        if clone_submodules?
+          git("submodule update --init --recursive")
+        end
       end
     end
 

--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -152,6 +152,7 @@ module Omnibus
     #
     def git_clone
       retry_block("custom git clone", [CommandTimeout, CommandFailed]) do
+        log.info(log_key) { "Cloning repository #{source_url} at revision #{resolved_version}" }
         git("init")
         git("remote add origin #{source_url}")
         git("fetch origin #{resolved_version}")


### PR DESCRIPTION
### Description

Instead of using git clone, we now fetch the right tag directly. It is impossible to clone to a specific revision so we need to fetch and checkout.
Used as part of this PR https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/53787106.
Job logs show the new log https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/777524284/raw.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
