### PR TITLE
feat(security): Pin the github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/no-auto-bump.yml
+++ b/.github/workflows/no-auto-bump.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           sync-labels: true

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
         id: app-token
         with:
           app-id: ${{ vars.DATADOG_APP_ID }}
@@ -19,7 +19,7 @@ jobs:
           repositories: datadog-agent
 
       - name: Clone datadog-agent repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: datadog/datadog-agent
           persist-credentials: false
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Clone omnibus-ruby repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: datadog/omnibus-ruby
           persist-credentials: false
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11.8"
           cache: "pip"
@@ -64,7 +64,7 @@ jobs:
           inv -e release.set-release-json 'nightly-a7::OMNIBUS_RUBY_VERSION'  ${{ steps.new_sha.outputs.NEW_SHA }}
 
       - name: create datadog-agent PR
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main


### PR DESCRIPTION
### Description
- Pin the github actions
- Enable dependabot

Aside from the PR the workflows settings had been updated to allow only the listed actions we need

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
