### PR TITLE
cli: rely on the existing use_s3_caching option to enable caching

### DIFF
--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -81,8 +81,8 @@ module Omnibus
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
       # Not sure why we need the !Omnibus::S3Cache.fetch_missing.empty? check here
-      Omnibus::S3Cache.populate if Omnibus::Config.use_s3_caching && !Omnibus::S3Cache.fetch_missing.empty?
-      Omnibus::S3LicenseCache.populate if Omnibus::Config.use_s3_caching
+      Omnibus::S3Cache.populate if Omnibus::Config.use_s3_caching && Omnibus::Config.s3_authenticated_download && !Omnibus::S3Cache.fetch_missing.empty?
+      Omnibus::S3LicenseCache.populate if Omnibus::Config.use_s3_caching && Omnibus::Config.s3_authenticated_download
       project.download
       project.build
 

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -81,6 +81,9 @@ module Omnibus
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
       # Not sure why we need the !Omnibus::S3Cache.fetch_missing.empty? check here
+      # We only want to populate the cache when we actually can. In some cases, we're only reading anonymously
+      # from the cache bucket (mostly when the build isn't ran on gitlab). When that is the case, we want to disable
+      # the cache population since it would fail.
       Omnibus::S3Cache.populate if Omnibus::Config.use_s3_caching && Omnibus::Config.s3_authenticated_download && !Omnibus::S3Cache.fetch_missing.empty?
       Omnibus::S3LicenseCache.populate if Omnibus::Config.use_s3_caching && Omnibus::Config.s3_authenticated_download
       project.download

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -70,10 +70,6 @@ module Omnibus
                   desc: "Use the given manifest when downloading software sources.",
                   type: :string,
                   default: nil
-    method_option :populate_s3_cache,
-                  desc: "Populate the S3 cache.",
-                  type: :boolean,
-                  default: false
     desc "build PROJECT", "Build the given Omnibus project"
     def build(name)
       manifest = if @options[:use_manifest]

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -85,8 +85,8 @@ module Omnibus
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
       # Not sure why we need the !Omnibus::S3Cache.fetch_missing.empty? check here
-      Omnibus::S3Cache.populate if @options[:populate_s3_cache] && !Omnibus::S3Cache.fetch_missing.empty?
-      Omnibus::S3LicenseCache.populate if @options[:populate_s3_cache]
+      Omnibus::S3Cache.populate if Omnibus::Config.use_s3_caching && !Omnibus::S3Cache.fetch_missing.empty?
+      Omnibus::S3LicenseCache.populate if Omnibus::Config.use_s3_caching
       project.download
       project.build
 


### PR DESCRIPTION
There's already a config value to enable sources caching, we can use it directly.
This is associated with https://github.com/DataDog/datadog-agent/pull/34835