### PR TITLE
[PathFetcher] Improve speed by removing unnecessary digest operations

### DIFF
--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -22,12 +22,12 @@ module Omnibus
 
     #
     # Fetch if the local directory checksum is different than the path directory
-    # checksum, or if the force_fetch option is set.
+    # checksum, or if target directory does not exist.
     #
     # @return [true, false]
     #
     def fetch_required?
-      return true if source[:force_fetch]
+      return true unless File.directory?(project_dir)
 
       target_shasum != destination_shasum
     end

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -21,13 +21,15 @@ module Omnibus
     @@source_path_mutexes = Hash.new { |h, k| h[k] = Mutex.new }
 
     #
-    # Fetch if the local directory checksum is different than the path directory
-    # checksum.
+    # Always fetch the local directory
+    # HACK: compared to upstream, makes fetching faster due to not having to compute hashes of large directories
+    # The downside of this is potentially copying sources using the PathFetcher when it is not needed (because of no changes)
+    # but this should be rare in Datadog projects, since the main use of the PathFetcher is for the git repository of the project.
     #
     # @return [true, false]
     #
     def fetch_required?
-      target_shasum != destination_shasum
+      true
     end
 
     #
@@ -67,7 +69,6 @@ module Omnibus
         FileSyncer.sync(source_path, project_dir, source_options)
         # Reset target shasum on every fetch
         @target_shasum = nil
-        target_shasum
       }
     end
 

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -28,6 +28,7 @@ module Omnibus
     #
     def fetch_required?
       return true if source[:force_fetch]
+
       target_shasum != destination_shasum
     end
 

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -21,15 +21,14 @@ module Omnibus
     @@source_path_mutexes = Hash.new { |h, k| h[k] = Mutex.new }
 
     #
-    # Always fetch the local directory
-    # HACK: compared to upstream, makes fetching faster due to not having to compute hashes of large directories
-    # The downside of this is potentially copying sources using the PathFetcher when it is not needed (because of no changes)
-    # but this should be rare in Datadog projects, since the main use of the PathFetcher is for the git repository of the project.
+    # Fetch if the local directory checksum is different than the path directory
+    # checksum, or if the force_fetch option is set.
     #
     # @return [true, false]
     #
     def fetch_required?
-      true
+      return true if source[:force_fetch]
+      target_shasum != destination_shasum
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -364,7 +364,7 @@ module Omnibus
           :git, :path, :url, :file, # fetcher types
           :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
-          :options, :force_fetch, # used by path_fetcher
+          :options, # used by path_fetcher
           :submodules, :always_fetch_tags # used by git_fetcher
         ]
         unless extra_keys.empty?

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -364,7 +364,7 @@ module Omnibus
           :git, :path, :url, :file, # fetcher types
           :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, :target_filename, # used by net_fetcher
-          :options, # used by path_fetcher
+          :options, :force_fetch, # used by path_fetcher
           :submodules, :always_fetch_tags # used by git_fetcher
         ]
         unless extra_keys.empty?


### PR DESCRIPTION
### Description

Improves the `PathFetcher` class' speed by removing some digest operations that are not neccesary, since they are quite costly (10-15s for a large directory like the `datadog-agent` repository).

Specifically:
- if the target directory (in the omnibus project directories) is empty, force a fetch without computing the digests of the source and the target: in this case, we know a fetch is required.
- after a fetch, do not pre-compute the digest of the target directory. In practice, it is a useless operation because this digest is never reused in the same omnibus run.

See [this document](https://docs.google.com/document/d/11hxQYMWCiv6e7aKxvF9lim-Ma2mDI-_zNymM3ZHlmj8/edit) for details.

I expect these improvements to reduce the duration of all Agent builds by about 30s.