### PR TITLE
file_syncer: force link creation

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -148,7 +148,7 @@ module Omnibus
           target = File.readlink(source_file)
 
           Dir.chdir(destination) do
-            FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
+            FileUtils.ln_sf(target, "#{destination}/#{relative_path}", force: true)
           end
         when :file
           source_stat = File.stat(source_file)


### PR DESCRIPTION
This fixes this kind of errors:
```
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/fileutils.rb:374:in `symlink': File exists @ syserr_fail2_in - /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/usm/testdata/root/testdata/bins/notjs/.. (Errno::EEXIST)
```
