### PR TITLE
Revert "file_syncer: force link creation (#231)"

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -148,7 +148,7 @@ module Omnibus
           target = File.readlink(source_file)
 
           Dir.chdir(destination) do
-            FileUtils.ln_sf(target, "#{destination}/#{relative_path}", force: true)
+            FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
           end
         when :file
           source_stat = File.stat(source_file)


### PR DESCRIPTION
This reverts commit cb2c9de1416444d46e26d432288c5375d970d940.

The change isn't correct and causes all builds to fail :grimacing: 