### PR TITLE
Globally disable documentation & manpages generation/installation

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -204,6 +204,7 @@ module Omnibus
 
       configure = options.delete(:bin) || "./configure"
       configure_cmd = [configure]
+      install_man = options.delete(:install_man) || false
 
       # Pass the host platform as well. Different versions of config.guess
       # arrive at differently terrible wild ass guesses for what MSYSTEM=MINGW64
@@ -220,6 +221,12 @@ module Omnibus
       default_prefix = if !windows? then "#{install_dir}/embedded" else python_3_embedded end
       prefix = options.delete(:prefix) || default_prefix
       configure_cmd << "--prefix=#{prefix}" if prefix && prefix != ""
+      unless install_man
+        man_dir = Dir.mktmpdir
+        # Force man pages to be installed in a dummy tmp dir unless
+        # installation is explicitely enabled
+        configure_cmd << "--mandir=#{man_dir}"
+      end
 
       configure_cmd.concat args
       configure_cmd = configure_cmd.join(" ").strip

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -789,6 +789,8 @@ module Omnibus
             # -z origin makes the rpath interpret the $ORIGIN variable as the binary path
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib,-z,origin -L#{install_dir}/embedded/lib -Wl,-rpath-link=#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+            # disable generating doc in most cases
+            "MAKEINFO" => "/bin/true",
           }
           # List of environment variables to forward and potentially map to an alternate name
           # If the value is nil, the key will simply be forwarded from ENV to flags


### PR DESCRIPTION
### Description

Disable generating most documentations, since we can't rely on `make install-exec` as we still need the headers to be installed.

Instead of spreading patches or alternate install targets throughout our software recipes, we can:
* Provide a dummy makeinfo executable through `MAKEINFO` env variable to disable documentation generation
* Install man pages in a dummy folder outside of the regular install folder. I couldn't find a way to disable those by default, but at least this way it won't end up in our git cache nor in our packages
