### PR TITLE
don't generate a temporary directory for manpages

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -222,9 +222,11 @@ module Omnibus
       prefix = options.delete(:prefix) || default_prefix
       configure_cmd << "--prefix=#{prefix}" if prefix && prefix != ""
       unless install_man
-        man_dir = Dir.mktmpdir
-        # Force man pages to be installed in a dummy tmp dir unless
-        # installation is explicitely enabled
+        # We can't generate a temporary directory here since it would cause
+        # the command line to change during each build, which causes the
+        # git cache tag to change for each build, rendering it useless
+        man_dir = Config.discard_dir
+        FileUtils.mkdir_p(man_dir)
         configure_cmd << "--mandir=#{man_dir}"
       end
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -225,7 +225,7 @@ module Omnibus
         # We can't generate a temporary directory here since it would cause
         # the command line to change during each build, which causes the
         # git cache tag to change for each build, rendering it useless
-        man_dir = Config.discard_dir
+        man_dir = Config.man_dir
         FileUtils.mkdir_p(man_dir)
         configure_cmd << "--mandir=#{man_dir}"
       end

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -131,6 +131,10 @@ module Omnibus
       File.join(base_dir, "discard")
     end
 
+    default(:man_dir) do
+      File.join(discard_dir, "man")
+    end
+
     # The absolute path to the directory on the virtual machine where
     # source code will be downloaded.
     #

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -127,6 +127,10 @@ module Omnibus
       File.join(base_dir, "cache", "git_cache")
     end
 
+    default(:discard_dir) do
+      File.join(base_dir, "discard")
+    end
+
     # The absolute path to the directory on the virtual machine where
     # source code will be downloaded.
     #


### PR DESCRIPTION
### Description

this causes the command line to change during each build, which changes the git cache tag and causes cache misses for every build
