### PR TITLE
Refactor packagers to expose safe_version without class instance

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -599,37 +599,7 @@ module Omnibus
     # @return [String]
     #
     def safe_version
-      version = project.build_version.dup
-
-      if version =~ /\-/
-        converted = version.tr("-", "~")
-
-        log.warn(log_key) do
-          "Dashes hold special significance in the Debian package versions. " \
-          "Versions that contain a dash and should be considered an earlier " \
-          "version (e.g. pre-releases) may actually be ordered as later " \
-          "(e.g. 12.0.0-rc.6 > 12.0.0). We'll work around this by replacing " \
-          "dashes (-) with tildes (~). Converting `#{project.build_version}' " \
-          "to `#{converted}'."
-        end
-
-        version = converted
-      end
-
-      if version =~ /\A[a-zA-Z0-9\.\+\:\~]+\z/
-        version
-      else
-        converted = version.gsub(/[^a-zA-Z0-9\.\+\:\~]+/, "_")
-
-        log.warn(log_key) do
-          "The `version' component of Debian package names can only include " \
-          "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
-          "plus signs (+), dashes (-), tildes (~) and colons (:). Converting " \
-          "`#{project.build_version}' to `#{converted}'."
-        end
-
-        converted
-      end
+      self.class.safe_version(project.build_version)
     end
 
     #
@@ -716,5 +686,45 @@ module Omnibus
       end
     end
     expose :compression_algo
+
+    #
+    # Return the Debian-ready version, replacing all dashes (+-+) with tildes
+    # (+~+) and converting any invalid characters to underscores (+_+).
+    #
+    # @return [String]
+    #
+    def self.safe_version(raw_version)
+      version = raw_version.dup
+
+      if version =~ /\-/
+        converted = version.tr("-", "~")
+
+        log.warn(log_key) do
+          "Dashes hold special significance in the Debian package versions. " \
+          "Versions that contain a dash and should be considered an earlier " \
+          "version (e.g. pre-releases) may actually be ordered as later " \
+          "(e.g. 12.0.0-rc.6 > 12.0.0). We'll work around this by replacing " \
+          "dashes (-) with tildes (~). Converting `#{version}' " \
+          "to `#{converted}'."
+        end
+
+        version = converted
+      end
+
+      if version =~ /\A[a-zA-Z0-9\.\+\:\~]+\z/
+        version
+      else
+        converted = version.gsub(/[^a-zA-Z0-9\.\+\:\~]+/, "_")
+
+        log.warn(log_key) do
+          "The `version' component of Debian package names can only include " \
+          "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
+          "plus signs (+), dashes (-), tildes (~) and colons (:). Converting " \
+          "`#{version}' to `#{converted}'."
+        end
+
+        converted
+      end
+    end
   end
 end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -707,52 +707,7 @@ module Omnibus
     # @return [String]
     #
     def safe_version
-      version = project.build_version.dup
-
-      # RPM 4.10+ added support for using the tilde (~) as a way to mark
-      # versions as lower priority in comparisons. More details on this
-      # feature can be found here:
-      #
-      #   http://rpm.org/ticket/56
-      #
-      if version =~ /\-/
-        if Ohai["platform_family"] == "wrlinux"
-          converted = version.tr("-", "_") # WRL has an elderly RPM version
-          log.warn(log_key) do
-            "Omnibus replaces dashes (-) with tildes (~) so pre-release " \
-            "versions get sorted earlier than final versions.  However, the " \
-            "version of rpmbuild on Wind River Linux does not support this. " \
-            "All dashes will be replaced with underscores (_). Converting " \
-            "`#{project.build_version}' to `#{converted}'."
-          end
-        else
-          converted = version.tr("-", "~")
-          log.warn(log_key) do
-            "Tildes hold special significance in the RPM package versions. " \
-            "They mark a version as lower priority in RPM's version compare " \
-            "logic. We'll replace all dashes (-) with tildes (~) so pre-release" \
-            "versions get sorted earlier then final versions. Converting" \
-            "`#{project.build_version}' to `#{converted}'."
-          end
-        end
-
-        version = converted
-      end
-
-      if version =~ /\A[a-zA-Z0-9\.\+\:\~]+\z/
-        version
-      else
-        converted = version.gsub(/[^a-zA-Z0-9\.\+\:\~]+/, "_")
-
-        log.warn(log_key) do
-          "The `version' component of RPM package names can only include " \
-          "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
-          "plus signs (+), tildes (~), colons (:) and underscores (_). " \
-          "Converting `#{project.build_version}' to `#{converted}'."
-        end
-
-        converted
-      end
+      self.class.safe_version(project.build_version)
     end
 
     #
@@ -883,5 +838,63 @@ module Omnibus
       end
     end
     expose :compression_algo
+
+    #
+    # Return a safe version string out of the input version
+    # RPM package versions cannot contain dashes, so we will convert them to
+    # underscores.
+    # @param [String] string
+    #   the string to sanitize
+    #
+    # @return [String]
+    #
+    def self.safe_version(raw_version)
+      # RPM 4.10+ added support for using the tilde (~) as a way to mark
+      # versions as lower priority in comparisons. More details on this
+      # feature can be found here:
+      #
+      #   http://rpm.org/ticket/56
+      #
+      version = raw_version.dup
+
+      if version =~ /\-/
+        if Ohai["platform_family"] == "wrlinux"
+          converted = version.tr("-", "_") # WRL has an elderly RPM version
+          log.warn(log_key) do
+            "Omnibus replaces dashes (-) with tildes (~) so pre-release " \
+            "versions get sorted earlier than final versions.  However, the " \
+            "version of rpmbuild on Wind River Linux does not support this. " \
+            "All dashes will be replaced with underscores (_). Converting " \
+            "`#{version}' to `#{converted}'."
+          end
+        else
+          converted = version.tr("-", "~")
+          log.warn(log_key) do
+            "Tildes hold special significance in the RPM package versions. " \
+            "They mark a version as lower priority in RPM's version compare " \
+            "logic. We'll replace all dashes (-) with tildes (~) so pre-release" \
+            "versions get sorted earlier then final versions. Converting" \
+            "`#{version}' to `#{converted}'."
+          end
+        end
+
+        version = converted
+      end
+
+      if version =~ /\A[a-zA-Z0-9\.\+\:\~]+\z/
+        version
+      else
+        converted = version.gsub(/[^a-zA-Z0-9\.\+\:\~]+/, "_")
+
+        log.warn(log_key) do
+          "The `version' component of RPM package names can only include " \
+          "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
+          "plus signs (+), tildes (~), colons (:) and underscores (_). " \
+          "Converting `#{version}' to `#{converted}'."
+        end
+
+        converted
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

I have a use case for exposing this as a "static method" to be able to apply the same transformation that Omnibus does to packages that we may depend on: https://github.com/DataDog/datadog-agent/blob/alopez/ot-only-packages/omnibus/config/projects/otel-agent.rb#L103-L104 (from https://github.com/DataDog/datadog-agent/pull/37647).

- This doesn't change any existing behavior.
- The alternative for this use case would be to have the build job depend on the depended-upon package artifact and parse that artifact's name to ensure the right version instead of reconstructing it based on conventions / assumptions. I decided against it because it complicates the build of the package (specially locally) without it really representing a build-time dependency.