### PR TITLE
use the usual package output directory for build summary

### DIFF
--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -90,8 +90,8 @@ module Omnibus
       project.build
 
       if @options[:output_manifest]
-        FileUtils.mkdir_p("pkg")
-        File.open(::File.join("pkg", "version-manifest.json"), "w") do |f|
+        FileUtils.mkdir_p(Omnibus::Config.package_dir)
+        File.open(::File.join(Omnibus::Config.package_dir, "version-manifest.json"), "w") do |f|
           f.write(FFI_Yajl::Encoder.encode(project.built_manifest.to_hash))
         end
       end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1481,7 +1481,7 @@ module Omnibus
     end
 
     def write_build_summary
-      out_path = "#{Config.project_root}/pkg/build-summary.json"
+      out_path = "#{Config.package_dir}/build-summary.json"
       log.info(log_key) { "Writing build summary to #{out_path}" }
       File.open(out_path, "w") do |f|
         f.write(FFI_Yajl::Encoder.encode(build_summary.to_hash, pretty: true))


### PR DESCRIPTION
This simplifies things for windows where we are currently outputing the summary into the sources location instead of the usual output one. No change is expected on linux where the package_dir is a subdirectory of the project_root

