### PR TITLE
[ABLD-77] Remove temporary `pip install dmgbuild`

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -143,7 +143,6 @@ module Omnibus
       log.info(log_key) { "Creating compressed dmg" }
 
       shellout! <<-EOH.gsub(/^ {8}/, "")
-        pip install dmgbuild==1.6.5
         dmgbuild \\
           --detach-retries=5 \\
           --settings="#{resource_path('settings.py')}" \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -109,7 +109,6 @@ module Omnibus
       it "runs the dmgbuild command" do
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
-            pip install dmgbuild==1.6.5
             dmgbuild \\
               --detach-retries=5 \\
               --settings="#{subject.resource_path('settings.py')}" \\


### PR DESCRIPTION
### Description
This is to address some technical debt left after #239 as per following comments:
- https://github.com/DataDog/omnibus-ruby/pull/239#discussion_r2182259545
- https://github.com/DataDog/omnibus-ruby/pull/239#pullrequestreview-2979286559

The dependency now comes from `dda`:
- DataDog/datadog-agent-dev#137