### PR TITLE
[ABLD-77] Revert "Remove temporary `pip install dmgbuild` (#241)"

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -143,6 +143,7 @@ module Omnibus
       log.info(log_key) { "Creating compressed dmg" }
 
       shellout! <<-EOH.gsub(/^ {8}/, "")
+        pip install dmgbuild==1.6.5
         dmgbuild \\
           --detach-retries=5 \\
           --settings="#{resource_path('settings.py')}" \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -109,6 +109,7 @@ module Omnibus
       it "runs the dmgbuild command" do
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
+            pip install dmgbuild==1.6.5
             dmgbuild \\
               --detach-retries=5 \\
               --settings="#{subject.resource_path('settings.py')}" \\


### PR DESCRIPTION
Because `dda` version is too old and doesn't bring `dmgbuild`. This would be fixed by DataDog/datadog-agent#38446, but there's reluctance to merge that change.

This reverts commit 6c5d581967e2880998cc621ad6e5f07a5c99f04a.