### PR TITLE
[ABLD-77] Reapply "Remove temporary `pip install dmgbuild`"

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -143,7 +143,6 @@ module Omnibus
       log.info(log_key) { "Creating compressed dmg" }
 
       shellout! <<-EOH.gsub(/^ {8}/, "")
-        pip install dmgbuild==1.6.5
         dmgbuild \\
           --detach-retries=5 \\
           --settings="#{resource_path('settings.py')}" \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -109,7 +109,6 @@ module Omnibus
       it "runs the dmgbuild command" do
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
-            pip install dmgbuild==1.6.5
             dmgbuild \\
               --detach-retries=5 \\
               --settings="#{subject.resource_path('settings.py')}" \\


### PR DESCRIPTION
### Description
Now DataDog/datadog-agent#39361 is merged, the resolution of `dda` leads to fetch `dmgbuild` as part of macOS build dependencies. The _ad hoc_ `pip install dmgbuild` should therefore no longer be necessary.

This reverts commit dd14a4b9f3221d5c74c343c24f4585810d5cd068 (#242) and thus reapplies commit 6c5d581967e2880998cc621ad6e5f07a5c99f04a (#241).