### PR TITLE
Optimize FileSyncer by using multithreading

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -152,7 +152,7 @@ module Omnibus
       source_files.each do |source_file|
         relative_path = relative_path_for(source_file, source)
         # Add source itself if it's a directory
-        if File.directory?(source_file)
+        if File.ftype(source_file) == "directory"
           dest_target = File.join(destination, relative_path)
           unless dir_mode_map.key?(dest_target)
             dir_mode_map[dest_target] = File.stat(source_file).mode

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -15,18 +15,11 @@
 #
 
 require "fileutils" unless defined?(FileUtils)
+require "omnibus/thread_pool"
 
 module Omnibus
   module FileSyncer
     extend self
-
-    def log
-      Omnibus.logger
-    end
-
-    def log_key
-      "FileSyncer"
-    end
 
     # Files to be ignored during a directory globbing
     IGNORED_FILES = %w{. ..}.freeze
@@ -125,9 +118,6 @@ module Omnibus
     # @return [true]
     #
     def sync(source, destination, options = {})
-      start_time = Time.now
-      log.info(log_key) { "Starting sync from '#{source}' to '#{destination}'" }
-
       unless File.directory?(source)
         raise ArgumentError, "`source' must be a directory, but was a " \
           "`#{File.ftype(source)}'! If you just want to sync a file, use " \
@@ -135,17 +125,12 @@ module Omnibus
       end
 
       # Collect source files
-      phase_start = Time.now
       source_files = all_files_under(source, options)
-      log.info(log_key) { "Collected #{source_files.size} source files in #{Time.now - phase_start}s" }
 
       # Clear any hardlink that we might have seen while syncing a previous directory
       # This can happen when generating 2 different packages in a row
       hardlink_sources.clear
 
-      # Build directory map
-      phase_start = Time.now
-      # Create all the needed directories in the destination with the right permissions
       # First gather all the directories and their permissions
       dir_mode_map = {}
       dir_mode_map[destination] = File.stat(source).mode
@@ -166,18 +151,11 @@ module Omnibus
           dir_mode_map[dest_dir] = File.stat(src_dir).mode
         end
       end
-      log.info(log_key) { "Built directory map with #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
-      # Create directories
-      phase_start = Time.now
       # Create directories sorted by depth (shallowest first) to ensure correct permissions
       dir_mode_map.sort_by { |path, _| path.count(File::SEPARATOR) }.each do |dest_dir, mode|
         FileUtils.mkdir_p(dest_dir, :mode => mode)
       end
-      log.info(log_key) { "Created #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
-
-      # Copy files and symlinks
-      phase_start = Time.now
 
       # Categorize files for processing
       regular_files = []
@@ -203,15 +181,11 @@ module Omnibus
         end
       end
 
-      log.info(log_key) { "Categorized #{regular_files.size} regular files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks" }
-
       # Process regular files and symlinks in parallel
-      require "omnibus/thread_pool"
       parallel_items = regular_files + symlinks
-      thread_count = [8, parallel_items.size].min  # Use up to 8 threads
+      thread_count = [8, parallel_items.size].min
 
       if parallel_items.any?
-        copy_start = Time.now
         ThreadPool.new(thread_count) do |pool|
           regular_files.each do |source_file|
             pool.schedule do
@@ -232,30 +206,23 @@ module Omnibus
             end
           end
         end
-        log.info(log_key) { "Copied #{regular_files.size} files and #{symlinks.size} symlinks in parallel (#{thread_count} threads) in #{Time.now - copy_start}s" }
       end
 
       # Process hardlinks serially (to maintain hardlink relationships)
-      if hardlinks.any?
-        hardlinks.each do |source_file, source_stat|
-          relative_path = relative_path_for(source_file, source)
-          if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
-            FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
-          else
-            begin
-              FileUtils.cp(source_file, "#{destination}/#{relative_path}")
-            rescue Errno::EACCES
-              FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
-            end
-            hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
+      hardlinks.each do |source_file, source_stat|
+        relative_path = relative_path_for(source_file, source)
+        if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
+          FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
+        else
+          begin
+            FileUtils.cp(source_file, "#{destination}/#{relative_path}")
+          rescue Errno::EACCES
+            FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
           end
+          hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
         end
       end
 
-      log.info(log_key) { "Copied #{regular_files.size} files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks in #{Time.now - phase_start}s" }
-
-      # Cleanup extra files
-      phase_start = Time.now
       # Remove any files in the destination that are not in the source files
       destination_files = glob("#{destination}/**/*")
 
@@ -274,9 +241,7 @@ module Omnibus
       extra_files.each do |file|
         FileUtils.rm_rf(File.join(destination, file))
       end
-      log.info(log_key) { "Removed #{extra_files.size} extra files in #{Time.now - phase_start}s" }
 
-      log.info(log_key) { "Sync completed in #{Time.now - start_time}s total" }
       true
     end
 

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -127,7 +127,7 @@ module Omnibus
     def sync(source, destination, options = {})
       start_time = Time.now
       log.info(log_key) { "Starting sync from '#{source}' to '#{destination}'" }
-      
+
       unless File.directory?(source)
         raise ArgumentError, "`source' must be a directory, but was a " \
           "`#{File.ftype(source)}'! If you just want to sync a file, use " \
@@ -176,62 +176,81 @@ module Omnibus
       end
       log.info(log_key) { "Created #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
-      # Phase 4: Copy files
+      # Phase 4: Copy files (parallelized)
       phase_start = Time.now
-      file_count = 0
-      symlink_count = 0
-      hardlink_count = 0
-      
-      # Copy over the filtered source files
-      source_files.each do |source_file|
-        relative_path = relative_path_for(source_file, source)
 
+      # Categorize files for processing
+      regular_files = []
+      symlinks = []
+      hardlinks = []
+
+      source_files.each do |source_file|
         case File.ftype(source_file).to_sym
         when :directory
-          # This is a directory, so we don't need to do anything because
-          # we created all the needed directories with the right permissions ahead of time
+          # Skip - already created
         when :link
-          target = File.readlink(source_file)
-
-          Dir.chdir(destination) do
-            FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
-          end
-          symlink_count += 1
+          symlinks << source_file
         when :file
           source_stat = File.stat(source_file)
-          # Detect 'files' which are hard links and use ln instead of cp to
-          # duplicate them, provided their source is in place already
-          if hardlink? source_stat
-            if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
-              FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
-            else
-              begin
-                FileUtils.cp(source_file, "#{destination}/#{relative_path}")
-              rescue Errno::EACCES
-                FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
-              end
-              hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
-            end
-            hardlink_count += 1
+          if hardlink?(source_stat)
+            hardlinks << [source_file, source_stat]
           else
-            # First attempt a regular copy. If we don't have write
-            # permission on the File, open will probably fail with
-            # EACCES (making it hard to sync files with permission
-            # r--r--r--). Rescue this error and use cp_r's
-            # :remove_destination option.
-            begin
-              FileUtils.cp(source_file, "#{destination}/#{relative_path}")
-            rescue Errno::EACCES
-              FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
-            end
-            file_count += 1
+            regular_files << source_file
           end
         else
           raise RuntimeError,
                 "Unknown file type: `File.ftype(source_file)' at `#{source_file}'!"
         end
       end
-      log.info(log_key) { "Copied #{file_count} files, #{hardlink_count} hardlinks, #{symlink_count} symlinks in #{Time.now - phase_start}s" }
+
+      log.info(log_key) { "Categorized #{regular_files.size} regular files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks" }
+
+      # Process regular files in parallel (the main bottleneck)
+      require "omnibus/thread_pool"
+      thread_count = [8, regular_files.size].min  # Use up to 8 threads
+
+      if regular_files.any?
+        copy_start = Time.now
+        ThreadPool.new(thread_count) do |pool|
+          regular_files.each do |source_file|
+            pool.schedule do
+              relative_path = relative_path_for(source_file, source)
+              begin
+                FileUtils.cp(source_file, "#{destination}/#{relative_path}")
+              rescue Errno::EACCES
+                FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
+              end
+            end
+          end
+        end
+        log.info(log_key) { "Copied #{regular_files.size} regular files in parallel (#{thread_count} threads) in #{Time.now - copy_start}s" }
+      end
+
+      # Process symlinks serially (usually few of them)
+      symlinks.each do |source_file|
+        relative_path = relative_path_for(source_file, source)
+        target = File.readlink(source_file)
+        Dir.chdir(destination) do
+          FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
+        end
+      end
+
+      # Process hardlinks serially (need to maintain hardlink relationships)
+      hardlinks.each do |source_file, source_stat|
+        relative_path = relative_path_for(source_file, source)
+        if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
+          FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
+        else
+          begin
+            FileUtils.cp(source_file, "#{destination}/#{relative_path}")
+          rescue Errno::EACCES
+            FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
+          end
+          hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
+        end
+      end
+
+      log.info(log_key) { "Total copied: #{regular_files.size} files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks in #{Time.now - phase_start}s" }
 
       # Phase 5: Cleanup extra files
       phase_start = Time.now

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -20,6 +20,14 @@ module Omnibus
   module FileSyncer
     extend self
 
+    def log
+      Omnibus.logger
+    end
+
+    def log_key
+      "FileSyncer"
+    end
+
     # Files to be ignored during a directory globbing
     IGNORED_FILES = %w{. ..}.freeze
 
@@ -117,18 +125,26 @@ module Omnibus
     # @return [true]
     #
     def sync(source, destination, options = {})
+      start_time = Time.now
+      log.info(log_key) { "Starting sync from '#{source}' to '#{destination}'" }
+      
       unless File.directory?(source)
         raise ArgumentError, "`source' must be a directory, but was a " \
           "`#{File.ftype(source)}'! If you just want to sync a file, use " \
           "the `copy' method instead."
       end
 
+      # Phase 1: Collect source files
+      phase_start = Time.now
       source_files = all_files_under(source, options)
+      log.info(log_key) { "Collected #{source_files.size} source files in #{Time.now - phase_start}s" }
 
       # Clear any hardlink that we might have seen while syncing a previous directory
       # This can happen when generating 2 different packages in a row
       hardlink_sources.clear
 
+      # Phase 2: Build directory map
+      phase_start = Time.now
       # Create all the needed directories in the destination with the right permissions
       # First gather all the directories and their permissions
       dir_mode_map = {}
@@ -150,12 +166,22 @@ module Omnibus
           dir_mode_map[dest_dir] = File.stat(src_dir).mode
         end
       end
+      log.info(log_key) { "Built directory map with #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
+      # Phase 3: Create directories
+      phase_start = Time.now
       # Then create all the directories
       dir_mode_map.each do |dest_dir, mode|
         FileUtils.mkdir_p(dest_dir, :mode => mode)
       end
+      log.info(log_key) { "Created #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
+      # Phase 4: Copy files
+      phase_start = Time.now
+      file_count = 0
+      symlink_count = 0
+      hardlink_count = 0
+      
       # Copy over the filtered source files
       source_files.each do |source_file|
         relative_path = relative_path_for(source_file, source)
@@ -170,6 +196,7 @@ module Omnibus
           Dir.chdir(destination) do
             FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
           end
+          symlink_count += 1
         when :file
           source_stat = File.stat(source_file)
           # Detect 'files' which are hard links and use ln instead of cp to
@@ -185,6 +212,7 @@ module Omnibus
               end
               hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
             end
+            hardlink_count += 1
           else
             # First attempt a regular copy. If we don't have write
             # permission on the File, open will probably fail with
@@ -196,13 +224,17 @@ module Omnibus
             rescue Errno::EACCES
               FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
             end
+            file_count += 1
           end
         else
           raise RuntimeError,
                 "Unknown file type: `File.ftype(source_file)' at `#{source_file}'!"
         end
       end
+      log.info(log_key) { "Copied #{file_count} files, #{hardlink_count} hardlinks, #{symlink_count} symlinks in #{Time.now - phase_start}s" }
 
+      # Phase 5: Cleanup extra files
+      phase_start = Time.now
       # Remove any files in the destination that are not in the source files
       destination_files = glob("#{destination}/**/*")
 
@@ -221,7 +253,9 @@ module Omnibus
       extra_files.each do |file|
         FileUtils.rm_rf(File.join(destination, file))
       end
+      log.info(log_key) { "Removed #{extra_files.size} extra files in #{Time.now - phase_start}s" }
 
+      log.info(log_key) { "Sync completed in #{Time.now - start_time}s total" }
       true
     end
 

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -134,7 +134,7 @@ module Omnibus
           "the `copy' method instead."
       end
 
-      # Phase 1: Collect source files
+      # Collect source files
       phase_start = Time.now
       source_files = all_files_under(source, options)
       log.info(log_key) { "Collected #{source_files.size} source files in #{Time.now - phase_start}s" }
@@ -143,7 +143,7 @@ module Omnibus
       # This can happen when generating 2 different packages in a row
       hardlink_sources.clear
 
-      # Phase 2: Build directory map
+      # Build directory map
       phase_start = Time.now
       # Create all the needed directories in the destination with the right permissions
       # First gather all the directories and their permissions
@@ -168,15 +168,15 @@ module Omnibus
       end
       log.info(log_key) { "Built directory map with #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
-      # Phase 3: Create directories
+      # Create directories
       phase_start = Time.now
-      # Then create all the directories
-      dir_mode_map.each do |dest_dir, mode|
+      # Create directories sorted by depth (shallowest first) to ensure correct permissions
+      dir_mode_map.sort_by { |path, _| path.count(File::SEPARATOR) }.each do |dest_dir, mode|
         FileUtils.mkdir_p(dest_dir, :mode => mode)
       end
       log.info(log_key) { "Created #{dir_mode_map.size} directories in #{Time.now - phase_start}s" }
 
-      # Phase 4: Copy files (parallelized)
+      # Copy files and symlinks
       phase_start = Time.now
 
       # Categorize files for processing
@@ -205,11 +205,12 @@ module Omnibus
 
       log.info(log_key) { "Categorized #{regular_files.size} regular files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks" }
 
-      # Process regular files in parallel (the main bottleneck)
+      # Process regular files and symlinks in parallel
       require "omnibus/thread_pool"
-      thread_count = [8, regular_files.size].min  # Use up to 8 threads
+      parallel_items = regular_files + symlinks
+      thread_count = [8, parallel_items.size].min  # Use up to 8 threads
 
-      if regular_files.any?
+      if parallel_items.any?
         copy_start = Time.now
         ThreadPool.new(thread_count) do |pool|
           regular_files.each do |source_file|
@@ -222,37 +223,38 @@ module Omnibus
               end
             end
           end
-        end
-        log.info(log_key) { "Copied #{regular_files.size} regular files in parallel (#{thread_count} threads) in #{Time.now - copy_start}s" }
-      end
 
-      # Process symlinks serially (usually few of them)
-      symlinks.each do |source_file|
-        relative_path = relative_path_for(source_file, source)
-        target = File.readlink(source_file)
-        Dir.chdir(destination) do
-          FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
-        end
-      end
-
-      # Process hardlinks serially (need to maintain hardlink relationships)
-      hardlinks.each do |source_file, source_stat|
-        relative_path = relative_path_for(source_file, source)
-        if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
-          FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
-        else
-          begin
-            FileUtils.cp(source_file, "#{destination}/#{relative_path}")
-          rescue Errno::EACCES
-            FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
+          symlinks.each do |source_file|
+            pool.schedule do
+              relative_path = relative_path_for(source_file, source)
+              target = File.readlink(source_file)
+              FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
+            end
           end
-          hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
+        end
+        log.info(log_key) { "Copied #{regular_files.size} files and #{symlinks.size} symlinks in parallel (#{thread_count} threads) in #{Time.now - copy_start}s" }
+      end
+
+      # Process hardlinks serially (to maintain hardlink relationships)
+      if hardlinks.any?
+        hardlinks.each do |source_file, source_stat|
+          relative_path = relative_path_for(source_file, source)
+          if existing = hardlink_sources[[source_stat.dev, source_stat.ino]]
+            FileUtils.ln(existing, "#{destination}/#{relative_path}", force: true)
+          else
+            begin
+              FileUtils.cp(source_file, "#{destination}/#{relative_path}")
+            rescue Errno::EACCES
+              FileUtils.cp_r(source_file, "#{destination}/#{relative_path}", remove_destination: true)
+            end
+            hardlink_sources.store([source_stat.dev, source_stat.ino], "#{destination}/#{relative_path}")
+          end
         end
       end
 
-      log.info(log_key) { "Total copied: #{regular_files.size} files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks in #{Time.now - phase_start}s" }
+      log.info(log_key) { "Copied #{regular_files.size} files, #{hardlinks.size} hardlinks, #{symlinks.size} symlinks in #{Time.now - phase_start}s" }
 
-      # Phase 5: Cleanup extra files
+      # Cleanup extra files
       phase_start = Time.now
       # Remove any files in the destination that are not in the source files
       destination_files = glob("#{destination}/**/*")

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -125,25 +125,45 @@ module Omnibus
 
       source_files = all_files_under(source, options)
 
-      # Ensure the destination directory exists
-      create_sync_dir(source, destination)
-
       # Clear any hardlink that we might have seen while syncing a previous directory
       # This can happen when generating 2 different packages in a row
       hardlink_sources.clear
+
+      # Create all the needed directories in the destination with the right permissions
+      # First gather all the directories and their permissions
+      dir_mode_map = {}
+      dir_mode_map[destination] = File.stat(source).mode
+      source_files.each do |source_file|
+        relative_path = relative_path_for(source_file, source)
+        # Add source itself if it's a directory
+        if File.directory?(source_file)
+          dest_target = File.join(destination, relative_path)
+          unless dir_mode_map.key?(dest_target)
+            dir_mode_map[dest_target] = File.stat(source_file).mode
+          end
+        end
+        # Add parent
+        dirname = File.dirname(relative_path)
+        dest_dir = File.join(destination, dirname)
+        unless dir_mode_map.key?(dest_dir)
+          src_dir = File.join(source, dirname)
+          dir_mode_map[dest_dir] = File.stat(src_dir).mode
+        end
+      end
+
+      # Then create all the directories
+      dir_mode_map.each do |dest_dir, mode|
+        FileUtils.mkdir_p(dest_dir, :mode => mode)
+      end
 
       # Copy over the filtered source files
       source_files.each do |source_file|
         relative_path = relative_path_for(source_file, source)
 
-        # Create the parent directory
-        dirname = File.dirname(relative_path)
-        parent = File.join(destination, dirname)
-        create_sync_dir(File.join(source, dirname), parent)
-
         case File.ftype(source_file).to_sym
         when :directory
-          create_sync_dir(File.join(source, relative_path), File.join(destination, relative_path))
+          # This is a directory, so we don't need to do anything because
+          # we created all the needed directories with the right permissions ahead of time
         when :link
           target = File.readlink(source_file)
 
@@ -247,20 +267,6 @@ module Omnibus
         stat.nlink > 1
       else
         false
-      end
-    end
-
-    #
-    # Create a "destination" directory with the same name and permissions
-    # as the source directory
-    #
-    def create_sync_dir(source, destination)
-      if not File.directory?(destination)
-        FileUtils.mkdir_p(destination, :mode => File.stat(source).mode)
-      else
-        if File.stat(source).mode != File.stat(destination).mode
-          File.chmod(File.stat(source).mode, destination)
-        end
       end
     end
   end


### PR DESCRIPTION
### Problem

This came out of an attempt at possible low-hanging fruit to make `PathFetcher` faster on Windows. On the [datadog-agent.rb](https://github.com/DataDog/datadog-agent/blob/c9022beb76c5637abd25524ec15c592f5522ef2e/omnibus/config/software/datadog-agent.rb#L29-L32) software definition, we instruct Omnibus to copy the source folder to a "staging" area, which Omnibus does via this `PathFetcher`, which currently takes around 9 minutes of the build on Windows. For cached builds taking 30-35 minutes represents 25 % of the job's runtime. This can be seen in [this example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1184669055#L392), with these timestamps as references:
```
[PathFetcher: datadog-agent] I | 2025-10-17T10:56:14+00:00 | Copying from `..'
...
[Licensing] I | 2025-10-17T11:05:25+00:00 | Software 'vc_redist_140' uses license 'Microsoft Visual Studio 2015' which is not one of the standard licenses identified in https://opensource.org/licenses/alphabetical. Consider using one of the standard licenses.
```

### Solution

I ended up finding out that copying files sequentially happens to be slow on Windows, and that multithreading sped the copy up by a lot.

Some jobs with logging gave me:

Single-thread ([source](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1182835854#L411)):
```
[FileSyncer] I | 2025-10-16T14:18:27+00:00 | Copied 63422 files, 0 hardlinks, 0 symlinks in 497.0327949s
```
Multi-threaded ([source](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1184780269#L412)):
```
[FileSyncer] I | 2025-10-17T12:15:57+00:00 | Copied 63436 files and 0 symlinks in parallel (8 threads) in 95.9001019s
```

Representing a 5x speedup. In total, this optimization results in the copy taking 2 minutes on Windows, which represents a 7 minute reduction. There's no noticeable effect on Linux builds.

Testing: builds triggered from [this pipeline](https://gitlab.ddbuild.io/DataDog/omnibus-ruby/-/pipelines/79624291) should work.