### PR TITLE
don't consider system provided .pc files

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -845,7 +845,7 @@ module Omnibus
         # always want to favor pkg-config from embedded location to not hose
         # configure scripts which try to be too clever and ignore our explicit
         # CFLAGS and LDFLAGS in favor of pkg-config info
-        merge({ "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig" }).
+        merge({ "PKG_CONFIG_LIBDIR" => "#{install_dir}/embedded/lib/pkgconfig" }).
         # Set default values for CXXFLAGS and CPPFLAGS.
         merge("CXXFLAGS" => compiler_flags["CFLAGS"])
          .merge("CPPFLAGS" => compiler_flags["CFLAGS"])


### PR DESCRIPTION
PKG_CONFIG_PATH appends a path to the default locations, which means we can fallback to /usr/lib/pkgconfig or similar.
PKG_CONFIG_LIBDIR replaces the defaults, and becomes the only location considered by pkg-config to find .pc files
