### PR TITLE
health check: also process .so on macOS

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -489,7 +489,7 @@ module Omnibus
       bad_libs = {}
       install_name = nil
 
-      yield_shellout_results("find #{project.install_dir} -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
+      yield_shellout_results("find #{project.install_dir} -type f | egrep '\.(dylib|bundle|so)$' | xargs otool -L") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]


### PR DESCRIPTION
To ensure python modules are linking with the correct libs
