### PR TITLE
Sort inputs to tar on the xz packager for improved reproducibility

### DIFF
--- a/lib/omnibus/packagers/xz.rb
+++ b/lib/omnibus/packagers/xz.rb
@@ -29,8 +29,9 @@ module Omnibus
       out_file = windows_safe_path(Config.package_dir, package_name)
       input_paths = ["#{windows_safe_path(project.install_dir)}/*"] + project.extra_package_files
       compress_env = { "XZ_OPT" => "-T#{compression_threads} -#{compression_level}" }
+      # --sort=name improves reproducibility
       cmd = <<-EOH.split.join(" ").squeeze(" ").strip
-        tar -cJf
+        tar --sort=name -cJf
         #{out_file}
         #{input_paths.join(" ")}
       EOH
@@ -39,7 +40,7 @@ module Omnibus
       if debug_build?
         out_file = windows_safe_path(Config.package_dir, package_name(true))
         cmd = <<-EOH.split.join(" ").squeeze(" ").strip
-          tar -cJf
+          tar --sort=name -cJf
           #{out_file}
           #{debug_package_paths.map { |dir| File.join(install_dir, dir) }.join(' ')}
         EOH


### PR DESCRIPTION
### Description

Makes sure files are always passed in the same order to tar, to try to reduce flakiness on static quality gates, where we see random changes to package (on-wire) sizes even when nothing really changed.

For reference, this is an example of how I've seen order to be different for two packages that come from the same commit (with a job retry):

```
root@c712e26f5a2c:/# tar -tf /archives/1431012497/omnibus/pkg/datadog-agent-7.77.0-devel.git.612.3f180f1.pipeline.96862361-1-arm64.tar.xz | grep opt/datadog-agent/LICENSES | head
opt/datadog-agent/LICENSES/
opt/datadog-agent/LICENSES/gstatus-GPL-3.0
opt/datadog-agent/LICENSES/systemd-LICENSE.GPL2
opt/datadog-agent/LICENSES/THIRD-PARTY-BSD-2-Clause
opt/datadog-agent/LICENSES/libsqlite3-Public-Domain
opt/datadog-agent/LICENSES/msodbcsql18-LICENSE.txt
opt/datadog-agent/LICENSES/zlib-LICENSE
opt/datadog-agent/LICENSES/jmxfetch-LICENSE
opt/datadog-agent/LICENSES/bzip2-LICENSE
opt/datadog-agent/LICENSES/acl-COPYING.LGPL
root@c712e26f5a2c:/# tar -tf /archives/1431099471/omnibus/pkg/datadog-agent-7.77.0-devel.git.612.3f180f1.pipeline.96862361-1-arm64.tar.xz | grep opt/datadog-agent/LICENSES | head
opt/datadog-agent/LICENSES/
opt/datadog-agent/LICENSES/libffi-LICENSE
opt/datadog-agent/LICENSES/THIRD-PARTY-MIT
opt/datadog-agent/LICENSES/freetds-COPYING.LIB
opt/datadog-agent/LICENSES/liblzma-COPYING
opt/datadog-agent/LICENSES/rpm-COPYING
opt/datadog-agent/LICENSES/nfsiostat-COPYING
opt/datadog-agent/LICENSES/curl-COPYING
opt/datadog-agent/LICENSES/libsqlite3-Public-Domain
opt/datadog-agent/LICENSES/bzip2-LICENSE
```

- Note 1: This might not help at all with the problem when done on the .xz packager, as these get repackaged into deb's and rpm's, I'll have a look at that next.
- Note 2: I'm aware that we're quite close to removing our reliance on omnibus for packaging, but with the investigation already done, this is low hanging fruit and it might save us from some pain in the static quality gates.