### PR TITLE
Add macos health check exclusions

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -136,6 +136,7 @@ module Omnibus
       # Symlink of the previous one
       /libgcc_s\.1\.dylib/,
       /CoreFoundation/,
+      /Foundation/,
       /CoreServices/,
       /Tcl$/,
       /Cocoa$/,
@@ -149,6 +150,7 @@ module Omnibus
       /libiconv/,
       /libstdc\+\+\.6\.dylib/,
       /libc\+\+\.1\.dylib/,
+      /libc\+\+abi\.dylib/,
       /libzstd\.1\.dylib/,
       /Security/,
       /SystemConfiguration/,


### PR DESCRIPTION
This adds a couple of exclusions to the omnibus health check in macos, to account for the use of the hermetic llvm_toolchain as implemented in https://github.com/DataDog/datadog-agent/pull/42894.

A build with the hermetic llvm_toolchain leads to health check errors (as in [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1601254651#L1812)) which look like this:

```
    --> /tmp/gitlabci/datadog-agent-build/bin/embedded/lib/libdatadog-agent-rtloader.0.1.0.dylib
    DEPENDS ON: libc++abi.dylib
      COUNT: 1
      PROVIDED BY: /usr/lib/libc++abi.dylib
      FAILED BECAUSE: Unsafe dependency
    --> /tmp/gitlabci/datadog-agent-build/bin/embedded/lib/libdatadog-agent-rtloader.0.1.0.dylib
    DEPENDS ON: Foundation
      COUNT: 1
      PROVIDED BY: /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
      FAILED BECAUSE: Unsafe dependency
```
(they repeat for every binary built with the toolchain)

These two dependencies are introduced [here](https://github.com/bazel-contrib/toolchains_llvm/blob/ace6215bbfe8a76884646b2458b42380e2201607/toolchain/cc_toolchain_config.bzl#L268) and [here](https://github.com/bazel-contrib/toolchains_llvm/blob/ace6215bbfe8a76884646b2458b42380e2201607/toolchain/cc_toolchain_config.bzl#L219), respectively. If my understanding is correct, these are added here pre-emptively in a static way because the hermetic toolchain favors explicitly calling the linker instead of driving the linker via `clang` itself, which would dynamically decide to add these flags depending on the inputs (e.g. whether there's c++ or objC code to be linked).

Both of these are system libraries that are shipped with macos and which therefore can be expected to exist on every macos installation. Therefore, it should be considered safe to link to them, and that's why this PR adds them to the existing "whitelist" which already includes.

I think this is the pragmatic solution, rather than trying to figure out a way for the toolchain to not add those flags.

These two jobs, ran against this branch, show that the exclusions make the previous failures go away:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1605594776
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1605594776