### PR TITLE
Support signing with beta channel in windows packager

### DIFF
--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -197,18 +197,31 @@ module Omnibus
     end
     expose :dd_wcssign
 
-    def dd_wcs_beta_channel(enabled = false)
-      if enabled
+    def dd_wcs_cert(val = NULL)
+      if val != NULL
         unless dd_wcssign
-          raise Error, "You must specify dd_wcssign with dd_wcs_beta_channel"
+          raise Error, "You must specify dd_wcssign with dd_wcs_cert"
         end
 
-        @dd_wcs_beta_channel = enabled
+        @dd_wcs_cert = val
       end
 
-      @dd_wcs_beta_channel
+      @dd_wcs_cert
     end
-    expose :dd_wcs_beta_channel
+    expose :dd_wcs_cert
+
+    def dd_wcs_config(val = NULL)
+      if val != NULL
+        unless dd_wcssign
+          raise Error, "You must specify dd_wcssign with dd_wcs_config"
+        end
+
+        @dd_wcs_config = val
+      end
+
+      @dd_wcs_config
+    end
+    expose :dd_wcs_config
 
     #
     # Iterates through available timestamp servers and tries to sign
@@ -256,10 +269,8 @@ module Omnibus
         cmd = Array.new.tap do |arr|
           arr << "dd-wcs"
           arr << "sign"
-          if dd_wcs_beta_channel
-            arr << "--cert s3://windows-code-signing-certificates/certs/beta/kms-signed.crt"
-            arr << "--config s3://windows-code-signing-certificates/certs/beta/config.json"
-          end
+          arr << "--cert #{dd_wcs_cert}" if dd_wcs_cert
+          arr << "--config #{dd_wcs_config}" if dd_wcs_config
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -197,6 +197,19 @@ module Omnibus
     end
     expose :dd_wcssign
 
+    def dd_wcs_beta_channel(enabled = false)
+      if enabled
+        unless dd_wcssign
+          raise Error, "You must specify dd_wcssign with dd_wcs_beta_channel"
+        end
+
+        @dd_wcs_beta_channel = enabled
+      end
+
+      @dd_wcs_beta_channel
+    end
+    expose :dd_wcs_beta_channel
+
     #
     # Iterates through available timestamp servers and tries to sign
     # the file with with each server, stopping after the first to succeed.
@@ -243,6 +256,10 @@ module Omnibus
         cmd = Array.new.tap do |arr|
           arr << "dd-wcs"
           arr << "sign"
+          if dd_wcs_beta_channel
+            arr << "--cert s3://windows-code-signing-certificates/certs/beta/kms-signed.crt"
+            arr << "--config s3://windows-code-signing-certificates/certs/beta/config.json"
+          end
           arr << "\"#{package_file}\""
         end.join(" ")
       elsif signing_identity


### PR DESCRIPTION
Add a flag on Windows packager to configure `dd-wcs` with beta channel for the signature. Goes together with: https://github.com/DataDog/datadog-agent/pull/50602
and is there to make sure #incident-52121 does not happen again

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
