### PR TITLE
Explicitly disable signing and annotating tags in git cache operations

### DIFF
--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -188,10 +188,16 @@ module Omnibus
     # recovery of build output. Hashes calculated on output files will be
     # invalid if we muck around with files after they have been produced.
     #
+    # We also explicitly disable GPG signing of commits and tags. The git cache
+    # is an internal implementation detail, and a user's global git config
+    # (e.g. commit.gpgSign=true or tag.gpgSign=true) would otherwise force
+    # signing, which requires a GPG key and turns lightweight tags into
+    # annotated ones, breaking the cache operations.
+    #
     # @return [Mixlib::Shellout] the underlying command object.
     #
     def git_cmd(command)
-      shellout!("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} #{command}")
+      shellout!("git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} #{command}")
     end
 
     #

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -85,7 +85,7 @@ module Omnibus
         expect(FileUtils).to receive(:mkdir_p)
           .with(File.dirname(ipc.cache_path))
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} init -q")
+          .with("git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} init -q")
         ipc.create_cache_path
       end
 
@@ -115,19 +115,19 @@ module Omnibus
       it "adds all the changes to git removing git directories" do
         expect(ipc).to receive(:remove_git_dirs)
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} add -A -f")
+          .with("git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} add -A -f")
         ipc.incremental
       end
 
       it "commits the backup for the software" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{ipc.tag}"})
         ipc.incremental
       end
 
       it "tags the software backup" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f "#{ipc.tag}"})
         ipc.incremental
       end
     end
@@ -167,10 +167,10 @@ module Omnibus
 
       before(:each) do
         allow(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         allow(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
         allow(ipc).to receive(:create_cache_path)
       end
 
@@ -181,10 +181,10 @@ module Omnibus
 
       it "checks for a tag with the software and version, and if it finds it, checks it out" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
         ipc.restore
       end
 
@@ -193,10 +193,10 @@ module Omnibus
 
         it "does nothing" do
           expect(ipc).to receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+            .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
             .and_return(tag_cmd)
           expect(ipc).to_not receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+            .with(%Q{git -c core.autocrlf=false -c commit.gpgSign=false -c tag.gpgSign=false -c tag.forceSignAnnotated=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
           ipc.restore
         end
       end


### PR DESCRIPTION


When tag.gpgSign=true is set it the global git config (which is a good practice I think), it break omnibus.build because it tries to sign and annotate git tags used by omnibus cache.
```
[Builder: datadog-agent-prepare] I | 2026-07-01T07:23:26+00:00 | Starting build
[Builder: datadog-agent-prepare] I | 2026-07-01T07:23:26+00:00 | <Dynamic Ruby block>: 0.0006s
[Builder: datadog-agent-prepare] I | 2026-07-01T07:23:26+00:00 | Build datadog-agent-prepare: 0.0013s
[Builder: datadog-agent-prepare] I | 2026-07-01T07:23:26+00:00 | Finished build
The following shell command exited with status 1:

    $ git -c core.autocrlf=false --git-dir=/var/cache/dd/omnibus/git-cache/opt/datadog-agent --work-tree=/opt/datadog-agent tag -f "datadog-agent-prepare-1537dc52c98c5536b1f2a246b311d85efe2f2b0911155ee522b2d90b97d4acc7-1"

Output:

    (nothing)

Error:

    error: Terminal is dumb, but EDITOR unset
```

Let's make it explicit that we should not sign/annotate those cache tags

