### PR TITLE
Stop renovate from doing major version updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-group :docs do
-  gem "yard",          "~> 0.8"
-  gem "redcarpet",     "~> 2.2.2"
-  gem "github-markup", "~> 0.7"
-end

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source "https://rubygems.org"
 gemspec
+
+group :docs do
+  gem "yard",          "~> 0.8"
+  gem "redcarpet",     "~> 2.2.2"
+  gem "github-markup", "~> 0.7"
+end

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
-  "ignorePaths": [".gitlab-ci.yml"]
+  "internalChecksFilter": "strict",
+  "ignorePaths": [".gitlab-ci.yml"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
### Description

Stop renovate from trying major version updates. That is just noise for a tool we are deprecating. This will prevent repeated PRs which come in and don't work.

### Motivation
This is an alternate to https://github.com/DataDog/omnibus-ruby/pull/259.  I'm tired of getting renovate updates to packages we don't need. That's a waste of our time to review and machine resources to add.

